### PR TITLE
Transfer usage restructuring and D3D11 async readback

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -177,6 +177,12 @@ typedef enum SDL_GpuBufferUsageFlagBits
 
 typedef Uint32 SDL_GpuBufferUsageFlags;
 
+typedef enum SDL_GpuTransferBufferUsage
+{
+    SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD,
+    SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD
+} SDL_GpuTransferBufferUsage;
+
 typedef enum SDL_GpuShaderStage
 {
     SDL_GPU_SHADERSTAGE_VERTEX,
@@ -936,7 +942,7 @@ extern SDL_DECLSPEC SDL_GpuBuffer *SDLCALL SDL_GpuCreateBuffer(
  * Creates a transfer buffer to be used when uploading to or downloading from graphics resources.
  *
  * \param device a GPU Context
- * \param uploadOnly specifies that the transfer buffer will only be used for uploads, allows optimizations on certain backends
+ * \param usage whether the transfer buffer will be used for uploads or downloads
  * \param sizeInBytes the size of the transfer buffer
  * \returns a transfer buffer on success, or NULL on failure
  *
@@ -950,7 +956,7 @@ extern SDL_DECLSPEC SDL_GpuBuffer *SDLCALL SDL_GpuCreateBuffer(
  */
 extern SDL_DECLSPEC SDL_GpuTransferBuffer *SDLCALL SDL_GpuCreateTransferBuffer(
     SDL_GpuDevice *device,
-    SDL_bool uploadOnly,
+    SDL_GpuTransferBufferUsage usage,
     Uint32 sizeInBytes);
 
 /* Debug Naming */

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -177,14 +177,6 @@ typedef enum SDL_GpuBufferUsageFlagBits
 
 typedef Uint32 SDL_GpuBufferUsageFlags;
 
-typedef enum SDL_GpuTransferBufferMapFlagBits
-{
-    SDL_GPU_TRANSFER_MAP_READ = 0x00000001,
-    SDL_GPU_TRANSFER_MAP_WRITE = 0x00000002
-} SDL_GpuTransferBufferMapFlagBits;
-
-typedef Uint32 SDL_GpuTransferBufferMapFlags;
-
 typedef enum SDL_GpuShaderStage
 {
     SDL_GPU_SHADERSTAGE_VERTEX,
@@ -335,12 +327,6 @@ typedef enum SDL_GpuBorderColor
     SDL_GPU_BORDERCOLOR_FLOAT_OPAQUE_WHITE,
     SDL_GPU_BORDERCOLOR_INT_OPAQUE_WHITE
 } SDL_GpuBorderColor;
-
-typedef enum SDL_GpuTransferUsage
-{
-    SDL_GPU_TRANSFERUSAGE_BUFFER,
-    SDL_GPU_TRANSFERUSAGE_TEXTURE
-} SDL_GpuTransferUsage;
 
 /*
  * VSYNC:
@@ -950,8 +936,7 @@ extern SDL_DECLSPEC SDL_GpuBuffer *SDLCALL SDL_GpuCreateBuffer(
  * Creates a transfer buffer to be used when uploading to or downloading from graphics resources.
  *
  * \param device a GPU Context
- * \param usage specifies whether the transfer buffer will transfer buffers or textures
- * \param mapFlags specify read-write options for the transfer buffer
+ * \param uploadOnly specifies that the transfer buffer will only be used for uploads, allows optimizations on certain backends
  * \param sizeInBytes the size of the transfer buffer
  * \returns a transfer buffer on success, or NULL on failure
  *
@@ -965,8 +950,7 @@ extern SDL_DECLSPEC SDL_GpuBuffer *SDLCALL SDL_GpuCreateBuffer(
  */
 extern SDL_DECLSPEC SDL_GpuTransferBuffer *SDLCALL SDL_GpuCreateTransferBuffer(
     SDL_GpuDevice *device,
-    SDL_GpuTransferUsage usage,
-    SDL_GpuTransferBufferMapFlags mapFlags,
+    SDL_bool uploadOnly,
     Uint32 sizeInBytes);
 
 /* Debug Naming */

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1060,7 +1060,7 @@ SDL_DYNAPI_PROC(SDL_GpuSampler*,SDL_GpuCreateSampler,(SDL_GpuDevice *a, SDL_GpuS
 SDL_DYNAPI_PROC(SDL_GpuShader*,SDL_GpuCreateShader,(SDL_GpuDevice *a, SDL_GpuShaderCreateInfo *b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_GpuTexture*,SDL_GpuCreateTexture,(SDL_GpuDevice *a, SDL_GpuTextureCreateInfo *b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_GpuBuffer*,SDL_GpuCreateBuffer,(SDL_GpuDevice *a, SDL_GpuBufferUsageFlags b, Uint32 c),(a,b,c),return)
-SDL_DYNAPI_PROC(SDL_GpuTransferBuffer*,SDL_GpuCreateTransferBuffer,(SDL_GpuDevice *a, SDL_GpuTransferUsage b, SDL_GpuTransferBufferMapFlags c, Uint32 d),(a,b,c,d),return)
+SDL_DYNAPI_PROC(SDL_GpuTransferBuffer*,SDL_GpuCreateTransferBuffer,(SDL_GpuDevice *a, SDL_bool b, Uint32 c),(a,b,c),return)
 SDL_DYNAPI_PROC(void,SDL_GpuSetBufferName,(SDL_GpuDevice *a, SDL_GpuBuffer *b, const char *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuSetTextureName,(SDL_GpuDevice *a, SDL_GpuTexture *b, const char *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuSetStringMarker,(SDL_GpuCommandBuffer *a, const char *b),(a,b),)

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1060,7 +1060,7 @@ SDL_DYNAPI_PROC(SDL_GpuSampler*,SDL_GpuCreateSampler,(SDL_GpuDevice *a, SDL_GpuS
 SDL_DYNAPI_PROC(SDL_GpuShader*,SDL_GpuCreateShader,(SDL_GpuDevice *a, SDL_GpuShaderCreateInfo *b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_GpuTexture*,SDL_GpuCreateTexture,(SDL_GpuDevice *a, SDL_GpuTextureCreateInfo *b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_GpuBuffer*,SDL_GpuCreateBuffer,(SDL_GpuDevice *a, SDL_GpuBufferUsageFlags b, Uint32 c),(a,b,c),return)
-SDL_DYNAPI_PROC(SDL_GpuTransferBuffer*,SDL_GpuCreateTransferBuffer,(SDL_GpuDevice *a, SDL_bool b, Uint32 c),(a,b,c),return)
+SDL_DYNAPI_PROC(SDL_GpuTransferBuffer*,SDL_GpuCreateTransferBuffer,(SDL_GpuDevice *a, SDL_GpuTransferBufferUsage b, Uint32 c),(a,b,c),return)
 SDL_DYNAPI_PROC(void,SDL_GpuSetBufferName,(SDL_GpuDevice *a, SDL_GpuBuffer *b, const char *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuSetTextureName,(SDL_GpuDevice *a, SDL_GpuTexture *b, const char *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuSetStringMarker,(SDL_GpuCommandBuffer *a, const char *b),(a,b),)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -444,15 +444,13 @@ SDL_GpuBuffer *SDL_GpuCreateBuffer(
 
 SDL_GpuTransferBuffer *SDL_GpuCreateTransferBuffer(
     SDL_GpuDevice *device,
-    SDL_GpuTransferUsage usage,
-    SDL_GpuTransferBufferMapFlags mapFlags,
+    SDL_bool uploadOnly,
     Uint32 sizeInBytes)
 {
     NULL_ASSERT(device)
     return device->CreateTransferBuffer(
         device->driverData,
-        usage,
-        mapFlags,
+        uploadOnly,
         sizeInBytes);
 }
 

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -444,13 +444,13 @@ SDL_GpuBuffer *SDL_GpuCreateBuffer(
 
 SDL_GpuTransferBuffer *SDL_GpuCreateTransferBuffer(
     SDL_GpuDevice *device,
-    SDL_bool uploadOnly,
+    SDL_GpuTransferBufferUsage usage,
     Uint32 sizeInBytes)
 {
     NULL_ASSERT(device)
     return device->CreateTransferBuffer(
         device->driverData,
-        uploadOnly,
+        usage,
         sizeInBytes);
 }
 

--- a/src/gpu/SDL_gpu_driver.h
+++ b/src/gpu/SDL_gpu_driver.h
@@ -231,8 +231,7 @@ struct SDL_GpuDevice
 
     SDL_GpuTransferBuffer *(*CreateTransferBuffer)(
         SDL_GpuRenderer *driverData,
-        SDL_GpuTransferUsage usage,
-        SDL_GpuTransferBufferMapFlags mapFlags,
+        SDL_bool uploadOnly,
         Uint32 sizeInBytes);
 
     /* Debug Naming */

--- a/src/gpu/SDL_gpu_driver.h
+++ b/src/gpu/SDL_gpu_driver.h
@@ -231,7 +231,7 @@ struct SDL_GpuDevice
 
     SDL_GpuTransferBuffer *(*CreateTransferBuffer)(
         SDL_GpuRenderer *driverData,
-        SDL_bool uploadOnly,
+        SDL_GpuTransferBufferUsage usage,
         Uint32 sizeInBytes);
 
     /* Debug Naming */

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -4739,6 +4739,8 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
         0);
 
     SDL_UnlockMutex(renderer->contextLock);
+
+    ID3D11Resource_Release(textureDownload->stagingTexture);
 }
 
 static void D3D11_INTERNAL_CleanCommandBuffer(

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -4710,7 +4710,7 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
     HRESULT res;
     Uint8 *dataPtr;
     Uint32 dataPtrOffset;
-    Uint32 depth, row, copySize;
+    Uint32 depth, row;
 
     SDL_LockMutex(renderer->contextLock);
     res = ID3D11DeviceContext_Map(

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -4708,7 +4708,6 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
 {
     D3D11_MAPPED_SUBRESOURCE subres;
     HRESULT res;
-    Uint8 *dataPtr;
     Uint32 dataPtrOffset;
     Uint32 depth, row;
 
@@ -4722,14 +4721,12 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
         &subres);
     ERROR_CHECK_RETURN("Could not map staging textre",)
 
-    dataPtr = (Uint8 *)subres.pData;
-
     for (depth = 0; depth < textureDownload->depth; depth += 1) {
         dataPtrOffset = textureDownload->bufferOffset + (depth * textureDownload->bytesPerDepthSlice);
 
         for (row = 0; row < textureDownload->height; row += 1) {
             SDL_memcpy(
-                dataPtr + dataPtrOffset,
+                transferBuffer->data + dataPtrOffset,
                 (Uint8 *)subres.pData + (depth * subres.DepthPitch) + (row * subres.RowPitch),
                 textureDownload->bytesPerRow);
             dataPtrOffset += textureDownload->bytesPerRow;

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -2660,8 +2660,6 @@ static void D3D11_MapTransferBuffer(
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)transferBuffer;
     D3D11TransferBuffer *buffer = container->activeBuffer;
-    D3D11_MAPPED_SUBRESOURCE mappedSubresource;
-    HRESULT res;
 
     /* Rotate the transfer buffer if necessary */
     if (
@@ -2681,8 +2679,8 @@ static void D3D11_UnmapTransferBuffer(
     SDL_GpuTransferBuffer *transferBuffer)
 {
     /* no-op */
-    (void*)driverData;
-    (void*)transferBuffer;
+    (void)driverData;
+    (void)transferBuffer;
 }
 
 static void D3D11_SetTransferData(
@@ -2694,7 +2692,6 @@ static void D3D11_SetTransferData(
 {
     D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)transferBuffer;
     void *dataPtr;
-    (void*)driverData;
 
     D3D11_MapTransferBuffer(driverData, transferBuffer, cycle, &dataPtr);
 

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1406,14 +1406,14 @@ static SDL_GpuBuffer *METAL_CreateBuffer(
 
 static SDL_GpuTransferBuffer *METAL_CreateTransferBuffer(
     SDL_GpuRenderer *driverData,
-    SDL_bool uploadOnly,
+    SDL_GpuTransferBufferUsage usage,
     Uint32 sizeInBytes)
 {
     return (SDL_GpuTransferBuffer *)METAL_INTERNAL_CreateBufferContainer(
         (MetalRenderer *)driverData,
         sizeInBytes,
         SDL_FALSE,
-        uploadOnly);
+        usage == SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD);
 }
 
 static MetalUniformBuffer *METAL_INTERNAL_CreateUniformBuffer(

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1374,8 +1374,7 @@ static MetalBufferContainer *METAL_INTERNAL_CreateBufferContainer(
 
     if (isPrivate) {
         resourceOptions = MTLResourceStorageModePrivate;
-    } else
-    {
+    } else {
         if (isWriteOnly) {
             resourceOptions = MTLResourceCPUCacheModeWriteCombined;
         } else {
@@ -1410,7 +1409,6 @@ static SDL_GpuTransferBuffer *METAL_CreateTransferBuffer(
     SDL_bool uploadOnly,
     Uint32 sizeInBytes)
 {
-    (void)usage;
     return (SDL_GpuTransferBuffer *)METAL_INTERNAL_CreateBufferContainer(
         (MetalRenderer *)driverData,
         sizeInBytes,
@@ -1452,12 +1450,14 @@ static void METAL_INTERNAL_CycleActiveBuffer(
         container->bufferCapacity,
         container->bufferCapacity + 1);
 
-    if (container->transferMapFlags == 0) {
+    if (container->isPrivate) {
         resourceOptions = MTLResourceStorageModePrivate;
-    } else if ((container->transferMapFlags & SDL_GPU_TRANSFER_MAP_WRITE) && !(container->transferMapFlags & SDL_GPU_TRANSFER_MAP_READ)) {
-        resourceOptions = MTLResourceCPUCacheModeWriteCombined;
     } else {
-        resourceOptions = MTLResourceCPUCacheModeDefaultCache;
+        if (container->isWriteOnly) {
+            resourceOptions = MTLResourceCPUCacheModeWriteCombined;
+        } else {
+            resourceOptions = MTLResourceCPUCacheModeDefaultCache;
+        }
     }
 
     container->buffers[container->bufferCount] = METAL_INTERNAL_CreateBuffer(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6766,8 +6766,7 @@ static VulkanUniformBuffer *VULKAN_INTERNAL_CreateUniformBuffer(
 
 static SDL_GpuTransferBuffer *VULKAN_CreateTransferBuffer(
     SDL_GpuRenderer *driverData,
-    SDL_GpuTransferUsage usage,             /* ignored on Vulkan */
-    SDL_GpuTransferBufferMapFlags mapFlags, /* ignored on Vulkan */
+    SDL_bool uploadOnly, /* ignored on Vulkan */
     Uint32 sizeInBytes)
 {
     return (SDL_GpuTransferBuffer *)VULKAN_INTERNAL_CreateBufferContainer(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6766,7 +6766,7 @@ static VulkanUniformBuffer *VULKAN_INTERNAL_CreateUniformBuffer(
 
 static SDL_GpuTransferBuffer *VULKAN_CreateTransferBuffer(
     SDL_GpuRenderer *driverData,
-    SDL_bool uploadOnly, /* ignored on Vulkan */
+    SDL_GpuTransferBufferUsage usage, /* ignored on Vulkan */
     Uint32 sizeInBytes)
 {
     return (SDL_GpuTransferBuffer *)VULKAN_INTERNAL_CreateBufferContainer(

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -455,8 +455,7 @@ init_render_state(void)
 
     buf_transfer = SDL_GpuCreateTransferBuffer(
         gpu_device,
-        SDL_GPU_TRANSFERUSAGE_BUFFER,
-        SDL_GPU_TRANSFER_MAP_WRITE,
+        SDL_TRUE,
         sizeof(vertex_data)
     );
     CHECK_CREATE(buf_transfer, "Vertex transfer buffer")


### PR DESCRIPTION
Found a workaround for D3D11, so these types are no longer needed.