### PR TITLE
Rename transfer parameters to source and destination

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -1705,17 +1705,17 @@ extern SDL_DECLSPEC SDL_GpuCopyPass *SDLCALL SDL_GpuBeginCopyPass(
  * the texel size of the texture format.
  *
  * \param copyPass a copy pass handle
- * \param transferBuffer a transfer buffer
- * \param textureRegion a struct containing parameters specifying the texture region to upload data to
- * \param copyParams a struct containing parameters specifying buffer offset, stride, and height
+ * \param source the source transfer buffer
+ * \param destination the destination texture region
+ * \param copyParams buffer offset, stride, and height
  * \param cycle if SDL_TRUE, cycles the texture if the texture slice is bound, otherwise overwrites the data.
  *
  * \since This function is available since SDL 3.x.x
  */
 extern SDL_DECLSPEC void SDLCALL SDL_GpuUploadToTexture(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuTransferBuffer *transferBuffer,
-    SDL_GpuTextureRegion *textureRegion,
+    SDL_GpuTransferBuffer *source,
+    SDL_GpuTextureRegion *destination,
     SDL_GpuBufferImageCopy *copyParams,
     SDL_bool cycle);
 
@@ -1727,17 +1727,17 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuUploadToTexture(
  * You may assume that the upload has finished in subsequent commands.
  *
  * \param copyPass a copy pass handle
- * \param transferBuffer a transfer buffer
- * \param buffer a buffer
- * \param copyParams a struct containing offsets and length
+ * \param source the source transfer buffer
+ * \param destination the destination buffer
+ * \param copyParams buffer offsets and length
  * \param cycle if SDL_TRUE, cycles the buffer if it is bound, otherwise overwrites the data.
  *
  * \since This function is available since SDL 3.x.x
  */
 extern SDL_DECLSPEC void SDLCALL SDL_GpuUploadToBuffer(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuTransferBuffer *transferBuffer,
-    SDL_GpuBuffer *buffer,
+    SDL_GpuTransferBuffer *source,
+    SDL_GpuBuffer *destination,
     SDL_GpuBufferCopy *copyParams,
     SDL_bool cycle);
 
@@ -1798,16 +1798,16 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuGenerateMipmaps(
  * This data is not guaranteed to be copied until the command buffer fence is signaled.
  *
  * \param copyPass a copy pass handle
- * \param textureRegion the texture region to download
- * \param transferBuffer the transfer buffer to download into
+ * \param source the source texture region
+ * \param destination the destination transfer buffer
  * \param copyParams a struct containing parameters specifying buffer offset, stride, and height
  *
  * \since This function is available since SDL 3.x.x
  */
 extern SDL_DECLSPEC void SDLCALL SDL_GpuDownloadFromTexture(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuTextureRegion *textureRegion,
-    SDL_GpuTransferBuffer *transferBuffer,
+    SDL_GpuTextureRegion *source,
+    SDL_GpuTransferBuffer *destination,
     SDL_GpuBufferImageCopy *copyParams);
 
 /**
@@ -1815,16 +1815,16 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuDownloadFromTexture(
  * This data is not guaranteed to be copied until the command buffer fence is signaled.
  *
  * \param copyPass a copy pass handle
- * \param buffer the buffer to download
- * \param transferBuffer the transfer buffer to download into
+ * \param source the source buffer
+ * \param destination the destination transfer buffer
  * \param copyParams a struct containing offsets and length
  *
  * \since This function is available since SDL 3.x.x
  */
 extern SDL_DECLSPEC void SDLCALL SDL_GpuDownloadFromBuffer(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuBuffer *buffer,
-    SDL_GpuTransferBuffer *transferBuffer,
+    SDL_GpuBuffer *source,
+    SDL_GpuTransferBuffer *destination,
     SDL_GpuBufferCopy *copyParams);
 
 /**

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1082,8 +1082,8 @@ SDL_GpuCopyPass *SDL_GpuBeginCopyPass(
 
 void SDL_GpuUploadToTexture(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuTransferBuffer *transferBuffer,
-    SDL_GpuTextureRegion *textureRegion,
+    SDL_GpuTransferBuffer *source,
+    SDL_GpuTextureRegion *destination,
     SDL_GpuBufferImageCopy *copyParams,
     SDL_bool cycle)
 {
@@ -1091,24 +1091,24 @@ void SDL_GpuUploadToTexture(
     CHECK_COPYPASS
     COPYPASS_DEVICE->UploadToTexture(
         COPYPASS_COMMAND_BUFFER,
-        transferBuffer,
-        textureRegion,
+        source,
+        destination,
         copyParams,
         cycle);
 }
 
 void SDL_GpuUploadToBuffer(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuTransferBuffer *transferBuffer,
-    SDL_GpuBuffer *buffer,
+    SDL_GpuTransferBuffer *source,
+    SDL_GpuBuffer *destination,
     SDL_GpuBufferCopy *copyParams,
     SDL_bool cycle)
 {
     NULL_ASSERT(copyPass)
     COPYPASS_DEVICE->UploadToBuffer(
         COPYPASS_COMMAND_BUFFER,
-        transferBuffer,
-        buffer,
+        source,
+        destination,
         copyParams,
         cycle);
 }
@@ -1155,29 +1155,29 @@ void SDL_GpuGenerateMipmaps(
 
 void SDL_GpuDownloadFromTexture(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuTextureRegion *textureRegion,
-    SDL_GpuTransferBuffer *transferBuffer,
+    SDL_GpuTextureRegion *source,
+    SDL_GpuTransferBuffer *destination,
     SDL_GpuBufferImageCopy *copyParams)
 {
     NULL_ASSERT(copyPass);
     COPYPASS_DEVICE->DownloadFromTexture(
         COPYPASS_COMMAND_BUFFER,
-        textureRegion,
-        transferBuffer,
+        source,
+        destination,
         copyParams);
 }
 
 void SDL_GpuDownloadFromBuffer(
     SDL_GpuCopyPass *copyPass,
-    SDL_GpuBuffer *buffer,
-    SDL_GpuTransferBuffer *transferBuffer,
+    SDL_GpuBuffer *source,
+    SDL_GpuTransferBuffer *destination,
     SDL_GpuBufferCopy *copyParams)
 {
     NULL_ASSERT(copyPass);
     COPYPASS_DEVICE->DownloadFromBuffer(
         COPYPASS_COMMAND_BUFFER,
-        buffer,
-        transferBuffer,
+        source,
+        destination,
         copyParams);
 }
 

--- a/src/gpu/SDL_gpu_driver.h
+++ b/src/gpu/SDL_gpu_driver.h
@@ -467,15 +467,15 @@ struct SDL_GpuDevice
 
     void (*UploadToTexture)(
         SDL_GpuCommandBuffer *commandBuffer,
-        SDL_GpuTransferBuffer *transferBuffer,
-        SDL_GpuTextureRegion *textureSlice,
+        SDL_GpuTransferBuffer *source,
+        SDL_GpuTextureRegion *destination,
         SDL_GpuBufferImageCopy *copyParams,
         SDL_bool cycle);
 
     void (*UploadToBuffer)(
         SDL_GpuCommandBuffer *commandBuffer,
-        SDL_GpuTransferBuffer *transferBuffer,
-        SDL_GpuBuffer *buffer,
+        SDL_GpuTransferBuffer *source,
+        SDL_GpuBuffer *destination,
         SDL_GpuBufferCopy *copyParams,
         SDL_bool cycle);
 
@@ -498,14 +498,14 @@ struct SDL_GpuDevice
 
     void (*DownloadFromTexture)(
         SDL_GpuCommandBuffer *commandBuffer,
-        SDL_GpuTextureRegion *textureSlice,
-        SDL_GpuTransferBuffer *transferBuffer,
+        SDL_GpuTextureRegion *source,
+        SDL_GpuTransferBuffer *destination,
         SDL_GpuBufferImageCopy *copyParams);
 
     void (*DownloadFromBuffer)(
         SDL_GpuCommandBuffer *commandBuffer,
-        SDL_GpuBuffer *buffer,
-        SDL_GpuTransferBuffer *transferBuffer,
+        SDL_GpuBuffer *source,
+        SDL_GpuTransferBuffer *destination,
         SDL_GpuBufferCopy *copyParams);
 
     void (*EndCopyPass)(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -8539,15 +8539,15 @@ static void VULKAN_BeginCopyPass(
 
 static void VULKAN_UploadToTexture(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTransferBuffer *transferBuffer,
-    SDL_GpuTextureRegion *textureRegion,
+    SDL_GpuTransferBuffer *source,
+    SDL_GpuTextureRegion *destination,
     SDL_GpuBufferImageCopy *copyParams,
     SDL_bool cycle)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
-    VulkanTextureContainer *vulkanTextureContainer = (VulkanTextureContainer *)textureRegion->textureSlice.texture;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source;
+    VulkanTextureContainer *vulkanTextureContainer = (VulkanTextureContainer *)destination->textureSlice.texture;
     VulkanTextureSlice *vulkanTextureSlice;
     VkBufferImageCopy imageCopy;
 
@@ -8557,21 +8557,21 @@ static void VULKAN_UploadToTexture(
         renderer,
         vulkanCommandBuffer,
         vulkanTextureContainer,
-        textureRegion->textureSlice.layer,
-        textureRegion->textureSlice.mipLevel,
+        destination->textureSlice.layer,
+        destination->textureSlice.mipLevel,
         cycle,
         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION);
 
-    imageCopy.imageExtent.width = textureRegion->w;
-    imageCopy.imageExtent.height = textureRegion->h;
-    imageCopy.imageExtent.depth = textureRegion->d;
-    imageCopy.imageOffset.x = textureRegion->x;
-    imageCopy.imageOffset.y = textureRegion->y;
-    imageCopy.imageOffset.z = textureRegion->z;
+    imageCopy.imageExtent.width = destination->w;
+    imageCopy.imageExtent.height = destination->h;
+    imageCopy.imageExtent.depth = destination->d;
+    imageCopy.imageOffset.x = destination->x;
+    imageCopy.imageOffset.y = destination->y;
+    imageCopy.imageOffset.z = destination->z;
     imageCopy.imageSubresource.aspectMask = vulkanTextureSlice->parent->aspectFlags;
-    imageCopy.imageSubresource.baseArrayLayer = textureRegion->textureSlice.layer;
+    imageCopy.imageSubresource.baseArrayLayer = destination->textureSlice.layer;
     imageCopy.imageSubresource.layerCount = 1;
-    imageCopy.imageSubresource.mipLevel = textureRegion->textureSlice.mipLevel;
+    imageCopy.imageSubresource.mipLevel = destination->textureSlice.mipLevel;
     imageCopy.bufferOffset = copyParams->bufferOffset;
     imageCopy.bufferRowLength = copyParams->bufferStride;
     imageCopy.bufferImageHeight = copyParams->bufferImageHeight;
@@ -8596,15 +8596,15 @@ static void VULKAN_UploadToTexture(
 
 static void VULKAN_UploadToBuffer(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTransferBuffer *transferBuffer,
-    SDL_GpuBuffer *buffer,
+    SDL_GpuTransferBuffer *source,
+    SDL_GpuBuffer *destination,
     SDL_GpuBufferCopy *copyParams,
     SDL_bool cycle)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
-    VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)buffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source;
+    VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)destination;
     VkBufferCopy bufferCopy;
 
     /* Note that the transfer buffer does not need a barrier, as it is synced by the client */
@@ -8641,16 +8641,16 @@ static void VULKAN_UploadToBuffer(
 
 static void VULKAN_DownloadFromTexture(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTextureRegion *textureRegion,
-    SDL_GpuTransferBuffer *transferBuffer,
+    SDL_GpuTextureRegion *source,
+    SDL_GpuTransferBuffer *destination,
     SDL_GpuBufferImageCopy *copyParams)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanTextureSlice *vulkanTextureSlice;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination;
     VkBufferImageCopy imageCopy;
-    vulkanTextureSlice = VULKAN_INTERNAL_SDLToVulkanTextureSlice(&textureRegion->textureSlice);
+    vulkanTextureSlice = VULKAN_INTERNAL_SDLToVulkanTextureSlice(&source->textureSlice);
 
     /* Note that the transfer buffer does not need a barrier, as it is synced by the client */
 
@@ -8660,16 +8660,16 @@ static void VULKAN_DownloadFromTexture(
         VULKAN_TEXTURE_USAGE_MODE_COPY_SOURCE,
         vulkanTextureSlice);
 
-    imageCopy.imageExtent.width = textureRegion->w;
-    imageCopy.imageExtent.height = textureRegion->h;
-    imageCopy.imageExtent.depth = textureRegion->d;
-    imageCopy.imageOffset.x = textureRegion->x;
-    imageCopy.imageOffset.y = textureRegion->y;
-    imageCopy.imageOffset.z = textureRegion->z;
+    imageCopy.imageExtent.width = source->w;
+    imageCopy.imageExtent.height = source->h;
+    imageCopy.imageExtent.depth = source->d;
+    imageCopy.imageOffset.x = source->x;
+    imageCopy.imageOffset.y = source->y;
+    imageCopy.imageOffset.z = source->z;
     imageCopy.imageSubresource.aspectMask = vulkanTextureSlice->parent->aspectFlags;
-    imageCopy.imageSubresource.baseArrayLayer = textureRegion->textureSlice.layer;
+    imageCopy.imageSubresource.baseArrayLayer = source->textureSlice.layer;
     imageCopy.imageSubresource.layerCount = 1;
-    imageCopy.imageSubresource.mipLevel = textureRegion->textureSlice.mipLevel;
+    imageCopy.imageSubresource.mipLevel = source->textureSlice.mipLevel;
     imageCopy.bufferOffset = copyParams->bufferOffset;
     imageCopy.bufferRowLength = copyParams->bufferStride;
     imageCopy.bufferImageHeight = copyParams->bufferImageHeight;
@@ -8694,14 +8694,14 @@ static void VULKAN_DownloadFromTexture(
 
 static void VULKAN_DownloadFromBuffer(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuBuffer *buffer,
-    SDL_GpuTransferBuffer *transferBuffer,
+    SDL_GpuBuffer *source,
+    SDL_GpuTransferBuffer *destination,
     SDL_GpuBufferCopy *copyParams)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
-    VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)buffer;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
+    VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)source;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination;
     VkBufferCopy bufferCopy;
 
     /* Note that transfer buffer does not need a barrier, as it is synced by the client */


### PR DESCRIPTION
This should clarify the usage of the parameters in the Upload/Download functions.