### PR TITLE
Remove depth bounds test

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -583,15 +583,12 @@ typedef struct SDL_GpuDepthStencilState
     SDL_bool depthTestEnable;
     SDL_bool depthWriteEnable;
     SDL_GpuCompareOp compareOp;
-    SDL_bool depthBoundsTestEnable;
     SDL_bool stencilTestEnable;
     SDL_GpuStencilOpState backStencilState;
     SDL_GpuStencilOpState frontStencilState;
     Uint32 compareMask;
     Uint32 writeMask;
     Uint32 reference;
-    float minDepthBounds;
-    float maxDepthBounds;
 } SDL_GpuDepthStencilState;
 
 typedef struct SDL_GpuColorAttachmentDescription

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -1349,10 +1349,6 @@ static ID3D11DepthStencilState *D3D11_INTERNAL_FetchDepthStencilState(
     dsDesc.StencilReadMask = depthStencilState.compareMask;
     dsDesc.StencilWriteMask = depthStencilState.writeMask;
 
-    if (depthStencilState.depthBoundsTestEnable) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D11 does not support Depth Bounds tests!");
-    }
-
     res = ID3D11Device_CreateDepthStencilState(
         renderer->device,
         &dsDesc,

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -935,7 +935,6 @@ static SDL_GpuGraphicsPipeline *METAL_CreateGraphicsPipeline(
 
     /* Depth Stencil */
 
-    /* FIXME: depth min/max? */
     if (pipelineCreateInfo->attachmentInfo.hasDepthStencilAttachment) {
         pipelineDescriptor.depthAttachmentPixelFormat = SDLToMetal_SurfaceFormat[pipelineCreateInfo->attachmentInfo.depthStencilFormat];
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6359,16 +6359,13 @@ static SDL_GpuGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     depthStencilStateCreateInfo.depthWriteEnable =
         pipelineCreateInfo->depthStencilState.depthWriteEnable;
     depthStencilStateCreateInfo.depthCompareOp = SDLToVK_CompareOp[pipelineCreateInfo->depthStencilState.compareOp];
-    depthStencilStateCreateInfo.depthBoundsTestEnable =
-        pipelineCreateInfo->depthStencilState.depthBoundsTestEnable;
+    depthStencilStateCreateInfo.depthBoundsTestEnable = VK_FALSE;
     depthStencilStateCreateInfo.stencilTestEnable =
         pipelineCreateInfo->depthStencilState.stencilTestEnable;
     depthStencilStateCreateInfo.front = frontStencilState;
     depthStencilStateCreateInfo.back = backStencilState;
-    depthStencilStateCreateInfo.minDepthBounds =
-        pipelineCreateInfo->depthStencilState.minDepthBounds;
-    depthStencilStateCreateInfo.maxDepthBounds =
-        pipelineCreateInfo->depthStencilState.maxDepthBounds;
+    depthStencilStateCreateInfo.minDepthBounds = 0; /* unused */
+    depthStencilStateCreateInfo.maxDepthBounds = 0; /* unused */
 
     /* Color Blend */
 


### PR DESCRIPTION
For the next batch of ABI breaks.

D3D11 and Metal don't support depth bounds tests at all, and Vulkan only supports them if the `depthBounds` feature is enabled (which we weren't using).