### PR TITLE
Remove support for border colors

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -319,20 +319,8 @@ typedef enum SDL_GpuSamplerAddressMode
 {
     SDL_GPU_SAMPLERADDRESSMODE_REPEAT,
     SDL_GPU_SAMPLERADDRESSMODE_MIRRORED_REPEAT,
-    SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE,
-    SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_BORDER
+    SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE
 } SDL_GpuSamplerAddressMode;
-
-/* FIXME: we should probably make a library-level decision about color types */
-typedef enum SDL_GpuBorderColor
-{
-    SDL_GPU_BORDERCOLOR_FLOAT_TRANSPARENT_BLACK,
-    SDL_GPU_BORDERCOLOR_INT_TRANSPARENT_BLACK,
-    SDL_GPU_BORDERCOLOR_FLOAT_OPAQUE_BLACK,
-    SDL_GPU_BORDERCOLOR_INT_OPAQUE_BLACK,
-    SDL_GPU_BORDERCOLOR_FLOAT_OPAQUE_WHITE,
-    SDL_GPU_BORDERCOLOR_INT_OPAQUE_WHITE
-} SDL_GpuBorderColor;
 
 /*
  * VSYNC:
@@ -486,7 +474,6 @@ typedef struct SDL_GpuSamplerCreateInfo
     SDL_GpuCompareOp compareOp;
     float minLod;
     float maxLod;
-    SDL_GpuBorderColor borderColor;
 } SDL_GpuSamplerCreateInfo;
 
 typedef struct SDL_GpuVertexBinding

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -374,40 +374,8 @@ static D3D11_INPUT_CLASSIFICATION SDLToD3D11_VertexInputRate[] = {
 static D3D11_TEXTURE_ADDRESS_MODE SDLToD3D11_SamplerAddressMode[] = {
     D3D11_TEXTURE_ADDRESS_WRAP,   /* REPEAT */
     D3D11_TEXTURE_ADDRESS_MIRROR, /* MIRRORED_REPEAT */
-    D3D11_TEXTURE_ADDRESS_CLAMP,  /* CLAMP_TO_EDGE */
-    D3D11_TEXTURE_ADDRESS_BORDER  /* CLAMP_TO_BORDER */
+    D3D11_TEXTURE_ADDRESS_CLAMP   /* CLAMP_TO_EDGE */
 };
-
-static void SDLToD3D11_BorderColor(
-    SDL_GpuSamplerCreateInfo *createInfo,
-    D3D11_SAMPLER_DESC *desc)
-{
-    switch (createInfo->borderColor) {
-    case SDL_GPU_BORDERCOLOR_FLOAT_OPAQUE_BLACK:
-    case SDL_GPU_BORDERCOLOR_INT_OPAQUE_BLACK:
-        desc->BorderColor[0] = 0.0f;
-        desc->BorderColor[1] = 0.0f;
-        desc->BorderColor[2] = 0.0f;
-        desc->BorderColor[3] = 1.0f;
-        break;
-
-    case SDL_GPU_BORDERCOLOR_FLOAT_OPAQUE_WHITE:
-    case SDL_GPU_BORDERCOLOR_INT_OPAQUE_WHITE:
-        desc->BorderColor[0] = 1.0f;
-        desc->BorderColor[1] = 1.0f;
-        desc->BorderColor[2] = 1.0f;
-        desc->BorderColor[3] = 1.0f;
-        break;
-
-    case SDL_GPU_BORDERCOLOR_FLOAT_TRANSPARENT_BLACK:
-    case SDL_GPU_BORDERCOLOR_INT_TRANSPARENT_BLACK:
-        desc->BorderColor[0] = 0.0f;
-        desc->BorderColor[1] = 0.0f;
-        desc->BorderColor[2] = 0.0f;
-        desc->BorderColor[3] = 0.0f;
-        break;
-    }
-}
 
 static D3D11_FILTER SDLToD3D11_Filter(SDL_GpuSamplerCreateInfo *createInfo)
 {
@@ -1879,17 +1847,13 @@ static SDL_GpuSampler *D3D11_CreateSampler(
     samplerDesc.AddressU = SDLToD3D11_SamplerAddressMode[samplerCreateInfo->addressModeU];
     samplerDesc.AddressV = SDLToD3D11_SamplerAddressMode[samplerCreateInfo->addressModeV];
     samplerDesc.AddressW = SDLToD3D11_SamplerAddressMode[samplerCreateInfo->addressModeW];
-
-    SDLToD3D11_BorderColor(
-        samplerCreateInfo,
-        &samplerDesc);
-
     samplerDesc.ComparisonFunc = (samplerCreateInfo->compareEnable ? SDLToD3D11_CompareOp[samplerCreateInfo->compareOp] : SDLToD3D11_CompareOp[SDL_GPU_COMPAREOP_ALWAYS]);
     samplerDesc.MaxAnisotropy = (samplerCreateInfo->anisotropyEnable ? (UINT)samplerCreateInfo->maxAnisotropy : 0);
     samplerDesc.Filter = SDLToD3D11_Filter(samplerCreateInfo);
     samplerDesc.MaxLOD = samplerCreateInfo->maxLod;
     samplerDesc.MinLOD = samplerCreateInfo->minLod;
     samplerDesc.MipLODBias = samplerCreateInfo->mipLodBias;
+    SDL_zeroa(samplerDesc.BorderColor); /* arbitrary, unused */
 
     res = ID3D11Device_CreateSamplerState(
         renderer->device,
@@ -6063,7 +6027,6 @@ static void D3D11_INTERNAL_InitBlitPipelines(
     samplerCreateInfo.mipLodBias = 0.0f;
     samplerCreateInfo.minLod = 0;
     samplerCreateInfo.maxLod = 1000;
-    samplerCreateInfo.borderColor = SDL_GPU_BORDERCOLOR_FLOAT_TRANSPARENT_BLACK;
 
     renderer->blitNearestSampler = D3D11_CreateSampler(
         (SDL_GpuRenderer *)renderer,

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -250,17 +250,7 @@ static MTLStencilOperation SDLToMetal_StencilOp[] = {
 static MTLSamplerAddressMode SDLToMetal_SamplerAddressMode[] = {
     MTLSamplerAddressModeRepeat,             /* REPEAT */
     MTLSamplerAddressModeMirrorRepeat,       /* MIRRORED_REPEAT */
-    MTLSamplerAddressModeClampToEdge,        /* CLAMP_TO_EDGE */
-    MTLSamplerAddressModeClampToBorderColor, /* CLAMP_TO_BORDER */
-};
-
-static MTLSamplerBorderColor SDLToMetal_BorderColor[] = {
-    MTLSamplerBorderColorTransparentBlack, /* FLOAT_TRANSPARENT_BLACK */
-    MTLSamplerBorderColorTransparentBlack, /* INT_TRANSPARENT_BLACK */
-    MTLSamplerBorderColorOpaqueBlack,      /* FLOAT_OPAQUE_BLACK */
-    MTLSamplerBorderColorOpaqueBlack,      /* INT_OPAQUE_BLACK */
-    MTLSamplerBorderColorOpaqueWhite,      /* FLOAT_OPAQUE_WHITE */
-    MTLSamplerBorderColorOpaqueWhite,      /* INT_OPAQUE_WHITE */
+    MTLSamplerAddressModeClampToEdge         /* CLAMP_TO_EDGE */
 };
 
 static MTLSamplerMinMagFilter SDLToMetal_MinMagFilter[] = {
@@ -1164,7 +1154,6 @@ static SDL_GpuSampler *METAL_CreateSampler(
     samplerDesc.rAddressMode = SDLToMetal_SamplerAddressMode[samplerCreateInfo->addressModeU];
     samplerDesc.sAddressMode = SDLToMetal_SamplerAddressMode[samplerCreateInfo->addressModeV];
     samplerDesc.tAddressMode = SDLToMetal_SamplerAddressMode[samplerCreateInfo->addressModeW];
-    samplerDesc.borderColor = SDLToMetal_BorderColor[samplerCreateInfo->borderColor];
     samplerDesc.minFilter = SDLToMetal_MinMagFilter[samplerCreateInfo->minFilter];
     samplerDesc.magFilter = SDLToMetal_MinMagFilter[samplerCreateInfo->magFilter];
     samplerDesc.mipFilter = SDLToMetal_MipFilter[samplerCreateInfo->mipmapMode]; /* FIXME: Is this right with non-mipmapped samplers? */
@@ -1172,6 +1161,7 @@ static SDL_GpuSampler *METAL_CreateSampler(
     samplerDesc.lodMaxClamp = samplerCreateInfo->maxLod;
     samplerDesc.maxAnisotropy = (NSUInteger)((samplerCreateInfo->anisotropyEnable) ? samplerCreateInfo->maxAnisotropy : 1);
     samplerDesc.compareFunction = (samplerCreateInfo->compareEnable) ? SDLToMetal_CompareOp[samplerCreateInfo->compareOp] : MTLCompareFunctionAlways;
+    samplerDesc.borderColor = MTLSamplerBorderColorTransparentBlack; /* arbitrary, unused */
 
     sampler = [renderer->device newSamplerStateWithDescriptor:samplerDesc];
     if (sampler == NULL) {
@@ -3620,7 +3610,6 @@ static void METAL_INTERNAL_InitBlitResources(
     samplerCreateInfo.mipLodBias = 0.0f;
     samplerCreateInfo.minLod = 0;
     samplerCreateInfo.maxLod = 1000;
-    samplerCreateInfo.borderColor = SDL_GPU_BORDERCOLOR_FLOAT_TRANSPARENT_BLACK;
 
     renderer->blitNearestSampler = METAL_CreateSampler(
         (SDL_GpuRenderer *)renderer,

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -324,17 +324,7 @@ static VkSamplerMipmapMode SDLToVK_SamplerMipmapMode[] = {
 static VkSamplerAddressMode SDLToVK_SamplerAddressMode[] = {
     VK_SAMPLER_ADDRESS_MODE_REPEAT,
     VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT,
-    VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
-    VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
-};
-
-static VkBorderColor SDLToVK_BorderColor[] = {
-    VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
-    VK_BORDER_COLOR_INT_TRANSPARENT_BLACK,
-    VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK,
-    VK_BORDER_COLOR_INT_OPAQUE_BLACK,
-    VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE,
-    VK_BORDER_COLOR_INT_OPAQUE_WHITE
+    VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE
 };
 
 /* Structures */
@@ -6602,7 +6592,7 @@ static SDL_GpuSampler *VULKAN_CreateSampler(
     vkSamplerCreateInfo.compareOp = SDLToVK_CompareOp[samplerCreateInfo->compareOp];
     vkSamplerCreateInfo.minLod = samplerCreateInfo->minLod;
     vkSamplerCreateInfo.maxLod = samplerCreateInfo->maxLod;
-    vkSamplerCreateInfo.borderColor = SDLToVK_BorderColor[samplerCreateInfo->borderColor];
+    vkSamplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK; /* arbitrary, unused */
     vkSamplerCreateInfo.unnormalizedCoordinates = VK_FALSE;
 
     vulkanResult = renderer->vkCreateSampler(


### PR DESCRIPTION
Vulkan requires that the border color of a sampler match the format (int vs. float) of the texture it will be used with. This is an annoying limitation for an already-niche feature, so let's just cut the feature entirely.