### PR TITLE
Swapchain parameter documentation

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -1901,6 +1901,14 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GpuSupportsPresentMode(
  * Claims a window, creating a swapchain structure for it.
  * This must be called before SDL_GpuAcquireSwapchainTexture is called using the window.
  *
+ * This function will fail if the requested present mode or swapchain composition
+ * are unsupported by the device. Check if the parameters are supported via
+ * SDL_GpuSupportsPresentMode / SDL_GpuSupportsSwapchainComposition prior to
+ * calling this function.
+ *
+ * SDL_GPU_PRESENTMODE_VSYNC and SDL_GPU_SWAPCHAINCOMPOSITION_SDR are
+ * always supported.
+ *
  * \param device a GPU context
  * \param window an SDL_Window
  * \param swapchainComposition the desired composition of the swapchain
@@ -1912,6 +1920,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GpuSupportsPresentMode(
  *
  * \sa SDL_GpuAcquireSwapchainTexture
  * \sa SDL_GpuUnclaimWindow
+ * \sa SDL_GpuSupportsPresentMode
+ * \sa SDL_GpuSupportsSwapchainComposition
  */
 extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GpuClaimWindow(
     SDL_GpuDevice *device,
@@ -1936,12 +1946,23 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuUnclaimWindow(
 /**
  * Changes the swapchain parameters for the given claimed window.
  *
+ * This function will fail if the requested present mode or swapchain composition
+ * are unsupported by the device. Check if the parameters are supported via
+ * SDL_GpuSupportsPresentMode / SDL_GpuSupportsSwapchainComposition prior to
+ * calling this function.
+ *
+ * SDL_GPU_PRESENTMODE_VSYNC and SDL_GPU_SWAPCHAINCOMPOSITION_SDR are
+ * always supported.
+ *
  * \param device a GPU context
  * \param window an SDL_Window that has been claimed
  * \param swapchainComposition the desired composition of the swapchain
  * \param presentMode the desired present mode for the swapchain
  *
  * \since This function is available since SDL 3.x.x
+ *
+ * \sa SDL_GpuSupportsPresentMode
+ * \sa SDL_GpuSupportsSwapchainComposition
  */
 extern SDL_DECLSPEC void SDLCALL SDL_GpuSetSwapchainParameters(
     SDL_GpuDevice *device,


### PR DESCRIPTION
Closes https://github.com/thatcosmonaut/SDL/issues/57. Added documentation about how swapchain parameters should be queried before calling ClaimWindow or SetSwapchainParameters. Though I am wondering if the latter should return an SDL_bool indicating whether it succeeded or not...