### PR TITLE
depthStencilAttachmentInfo is allowed to be null

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -798,10 +798,6 @@ SDL_GpuRenderPass *SDL_GpuBeginRenderPass(
         SDL_InvalidParamError("colorAttachmentInfos");
         return NULL;
     }
-    if (depthStencilAttachmentInfo == NULL) {
-        SDL_InvalidParamError("depthStencilAttachmentInfo");
-        return NULL;
-    }
 
     CHECK_COMMAND_BUFFER_RETURN_NULL
     CHECK_ANY_PASS_IN_PROGRESS


### PR DESCRIPTION
This check was causing almost all of the SDL_gpu_examples to fail.