### PR TITLE
improved vulkan memory type iteration

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -2426,12 +2426,12 @@ static Uint8 VULKAN_INTERNAL_BindMemoryForBuffer(
      *   On UMA systems like iPhone or Nintendo Switch all memory is device-local.
      *
      * HOST_VISIBLE:
-     *   This memory can be mapped for host access, meaning we can write
-     *   directly to the memory with pointer access.
+     *   This memory can be mapped for host access, meaning we can obtain
+     *   a pointer to directly access the memory.
      *
      * HOST_COHERENT:
      *   Host-coherent memory does not require cache management operations
-     *   when mapped, so we generally set this alongside HOST_VISIBLE
+     *   when mapped, so we always set this alongside HOST_VISIBLE
      *   to avoid extra record keeping.
      *
      * HOST_CACHED:

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1786,9 +1786,13 @@ static Uint32* VULKAN_INTERNAL_FindBestMemoryTypes(
     Uint32 *pCount)
 {
     Uint32 i;
-    Uint32 count = 0;
     Uint32 index = 0;
     Uint32 *result = NULL;
+
+    /* Initialize array */
+    result = SDL_malloc(sizeof(Uint32) * renderer->memoryProperties.memoryTypeCount);
+
+    /* Set array values in order of preference */
 
     /* required + preferred + !allowed */
     for (i = 0; i < renderer->memoryProperties.memoryTypeCount; i += 1) {
@@ -1796,7 +1800,14 @@ static Uint32* VULKAN_INTERNAL_FindBestMemoryTypes(
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & preferredProperties) == preferredProperties &&
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & allowedProperties) == 0) {
-            count += 1;
+            if (VULKAN_INTERNAL_CheckMemoryTypeArrayUnique(
+                i,
+                result,
+                index
+            )) {
+                result[index] = i;
+                index += 1;
+            }
         }
     }
 
@@ -1806,7 +1817,14 @@ static Uint32* VULKAN_INTERNAL_FindBestMemoryTypes(
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & preferredProperties) == 0 &&
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & allowedProperties) == 0) {
-            count += 1;
+            if (VULKAN_INTERNAL_CheckMemoryTypeArrayUnique(
+                i,
+                result,
+                index
+            )) {
+                result[index] = i;
+                index += 1;
+            }
         }
     }
 
@@ -1816,72 +1834,18 @@ static Uint32* VULKAN_INTERNAL_FindBestMemoryTypes(
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & preferredProperties) == preferredProperties &&
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & allowedProperties) == allowedProperties) {
-            count += 1;
+            if (VULKAN_INTERNAL_CheckMemoryTypeArrayUnique(
+                i,
+                result,
+                index
+            )) {
+                result[index] = i;
+                index += 1;
+            }
         }
     }
 
     /* required + !preferred + allowed */
-    for (i = 0; i < renderer->memoryProperties.memoryTypeCount; i += 1) {
-        if ((typeFilter & (1 << i)) &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & preferredProperties) == 0 &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & allowedProperties) == allowedProperties) {
-            count += 1;
-        }
-    }
-
-    /* Initialize array */
-    result = SDL_malloc(sizeof(Uint32) * count);
-
-    /* Set array values in order of preference */
-    for (i = 0; i < renderer->memoryProperties.memoryTypeCount; i += 1) {
-        if ((typeFilter & (1 << i)) &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & preferredProperties) == preferredProperties &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & allowedProperties) == 0) {
-            if (VULKAN_INTERNAL_CheckMemoryTypeArrayUnique(
-                i,
-                result,
-                index
-            )) {
-                result[index] = i;
-                index += 1;
-            }
-        }
-    }
-
-    for (i = 0; i < renderer->memoryProperties.memoryTypeCount; i += 1) {
-        if ((typeFilter & (1 << i)) &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & preferredProperties) == 0 &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & allowedProperties) == 0) {
-            if (VULKAN_INTERNAL_CheckMemoryTypeArrayUnique(
-                i,
-                result,
-                index
-            )) {
-                result[index] = i;
-                index += 1;
-            }
-        }
-    }
-
-    for (i = 0; i < renderer->memoryProperties.memoryTypeCount; i += 1) {
-        if ((typeFilter & (1 << i)) &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & preferredProperties) == preferredProperties &&
-            (renderer->memoryProperties.memoryTypes[i].propertyFlags & allowedProperties) == allowedProperties) {
-            if (VULKAN_INTERNAL_CheckMemoryTypeArrayUnique(
-                i,
-                result,
-                index
-            )) {
-                result[index] = i;
-                index += 1;
-            }
-        }
-    }
-
     for (i = 0; i < renderer->memoryProperties.memoryTypeCount; i += 1) {
         if ((typeFilter & (1 << i)) &&
             (renderer->memoryProperties.memoryTypes[i].propertyFlags & requiredProperties) == requiredProperties &&

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -2474,7 +2474,7 @@ static Uint8 VULKAN_INTERNAL_BindMemoryForBuffer(
      * memory in this situation because, as mentioned above,
      * on certain devices all memory is device-local, and even
      * though the transfer isn't strictly necessary it is still
-     * useful for correctly timelining transfers.
+     * useful for correctly timelining data.
      */
     if (type == VULKAN_BUFFER_TYPE_GPU) {
         preferredMemoryPropertyFlags |=

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1785,7 +1785,7 @@ static Uint32* VULKAN_INTERNAL_FindBestMemoryTypes(
     VkMemoryPropertyFlags allowedProperties,
     Uint32 *pCount)
 {
-    Uint32 i, j;
+    Uint32 i;
     Uint32 count = 0;
     Uint32 index = 0;
     Uint32 *result = NULL;
@@ -1833,7 +1833,6 @@ static Uint32* VULKAN_INTERNAL_FindBestMemoryTypes(
     /* Initialize array */
     result = SDL_malloc(sizeof(Uint32) * count);
 
-    SDL_bool unique;
     /* Set array values in order of preference */
     for (i = 0; i < renderer->memoryProperties.memoryTypeCount; i += 1) {
         if ((typeFilter & (1 << i)) &&
@@ -2396,7 +2395,7 @@ static Uint8 VULKAN_INTERNAL_BindMemoryForImage(
             image,
             usedRegion);
 
-        if (bindResult = 1) {
+        if (bindResult == 1) {
             selectedMemoryTypeIndex = memoryTypesToTry[i];
             break;
         }


### PR DESCRIPTION
Changed Vulkan memory binding to not have to get the filter types repeatedly. Broke down memory properties into required, preferred, and tolerable. Additionally, transfer buffers now require coherent memory.