### PR TITLE
Don't ignore entryPointName in d3d11 backend.

### DIFF
--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -1474,7 +1474,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
             NULL,
             NULL,
             NULL,
-            "main", /* entry point name ignored */
+            entryPointName,
             profiles[stage],
             0,
             0,


### PR DESCRIPTION
When compiling an hlsl shader on D3D11 currently the entryPointName is being ignored.

## Description
Switched from the hardcoded "main" to using what was passed in to the function already from the user.
