### PR TITLE
Update Blit implementations to use vertexCount

### DIFF
--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -4317,11 +4317,7 @@ static void D3D11_Blit(
         &textureSamplerBinding,
         1);
 
-    D3D11_DrawPrimitives(
-        commandBuffer,
-        0,
-        1);
-
+    D3D11_DrawPrimitives(commandBuffer, 0, 3);
     D3D11_EndRenderPass(commandBuffer);
 }
 

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -5267,11 +5267,7 @@ static void D3D12_Blit(
         &blitFragmentUniforms,
         sizeof(BlitFragmentUniforms));
 
-    D3D12_DrawPrimitives(
-        commandBuffer,
-        0,
-        1);
-
+    D3D12_DrawPrimitives(commandBuffer, 0, 3);
     D3D12_EndRenderPass(commandBuffer);
 }
 
@@ -7406,4 +7402,4 @@ SDL_GpuDriver D3D12Driver = {
     D3D12_CreateDevice
 };
 
-#endif /* SDL_GPU_D12 */
+#endif /* SDL_GPU_D3D12 */

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3048,7 +3048,7 @@ static void METAL_Blit(
         &textureSamplerBinding,
         1);
 
-    METAL_DrawPrimitives(commandBuffer, 0, 1);
+    METAL_DrawPrimitives(commandBuffer, 0, 3);
     METAL_EndRenderPass(commandBuffer);
 }
 


### PR DESCRIPTION
Pretty self-explanatory. This fixes the Blit regression on D3D11, D3D12, and Metal.