### PR TITLE
Remove SetTransferData/GetTransferData APIs

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -424,13 +424,6 @@ typedef struct SDL_GpuTransferBufferLocation
     Uint32 offset;
 } SDL_GpuTransferBufferLocation;
 
-typedef struct SDL_GpuTransferBufferRegion
-{
-    SDL_GpuTransferBuffer *transferBuffer;
-    Uint32 offset;
-    Uint32 size;
-} SDL_GpuTransferBufferRegion;
-
 typedef struct SDL_GpuTextureSlice
 {
     SDL_GpuTexture *texture;
@@ -1329,8 +1322,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuPushComputeUniformData(
  * or if none are available, a new one is created.
  * This means you don't have to worry about complex state tracking and synchronization as long as cycling is correctly employed.
  *
- * For example: you can call SetTransferData and then UploadToTexture. The next time you call SetTransferData,
- * if you set the cycle param to SDL_TRUE, you don't have to worry about overwriting any data that is not yet uploaded.
+ * For example: you can call MapTransferBuffer, write texture data, UnmapTransferBuffer, and then UploadToTexture.
+ * The next time you write texture data to the transfer buffer, if you set the cycle param to SDL_TRUE, you don't have
+ * to worry about overwriting any data that is not yet uploaded.
  *
  * Another example: If you are using a texture in a render pass every frame, this can cause a data dependency between frames.
  * If you set cycle to SDL_TRUE in the ColorAttachmentInfo struct, you can prevent this data dependency.
@@ -1799,36 +1793,6 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuUnmapTransferBuffer(
     SDL_GpuDevice *device,
     SDL_GpuTransferBuffer *transferBuffer);
 
-/**
- * Immediately copies data from a pointer to a transfer buffer.
- *
- * \param device a GPU context
- * \param source a pointer to data to copy into the transfer buffer
- * \param destination a transfer buffer with offset and size
- * \param cycle if SDL_TRUE, cycles the transfer buffer if it is bound, otherwise overwrites the data.
- *
- * \since This function is available since SDL 3.x.x
- */
-extern SDL_DECLSPEC void SDLCALL SDL_GpuSetTransferData(
-    SDL_GpuDevice *device,
-    const void *source,
-    SDL_GpuTransferBufferRegion *destination,
-    SDL_bool cycle);
-
-/**
- * Immediately copies data from a transfer buffer to a pointer.
- *
- * \param device a GPU context
- * \param source a transfer buffer with offset and size
- * \param destination a data pointer
- *
- * \since This function is available since SDL 3.x.x
- */
-extern SDL_DECLSPEC void SDLCALL SDL_GpuGetTransferData(
-    SDL_GpuDevice *device,
-    SDL_GpuTransferBufferRegion *source,
-    void *destination);
-
 /* Copy Pass */
 
 /**
@@ -2257,7 +2221,6 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuReleaseFence(
  *
  * \since This function is available since SDL 3.x.x
  *
- * \sa SDL_GpuSetTransferData
  * \sa SDL_GpuUploadToTexture
  */
 extern SDL_DECLSPEC Uint32 SDLCALL SDL_GpuTextureFormatTexelBlockSize(

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -1118,8 +1118,6 @@ SDL3_0.0.0 {
     SDL_GpuEndComputePass;
     SDL_GpuMapTransferBuffer;
     SDL_GpuUnmapTransferBuffer;
-    SDL_GpuSetTransferData;
-    SDL_GpuGetTransferData;
     SDL_GpuBeginCopyPass;
     SDL_GpuUploadToTexture;
     SDL_GpuUploadToBuffer;

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -1143,8 +1143,6 @@
 #define SDL_GpuEndComputePass SDL_GpuEndComputePass_REAL
 #define SDL_GpuMapTransferBuffer SDL_GpuMapTransferBuffer_REAL
 #define SDL_GpuUnmapTransferBuffer SDL_GpuUnmapTransferBuffer_REAL
-#define SDL_GpuSetTransferData SDL_GpuSetTransferData_REAL
-#define SDL_GpuGetTransferData SDL_GpuGetTransferData_REAL
 #define SDL_GpuBeginCopyPass SDL_GpuBeginCopyPass_REAL
 #define SDL_GpuUploadToTexture SDL_GpuUploadToTexture_REAL
 #define SDL_GpuUploadToBuffer SDL_GpuUploadToBuffer_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1150,8 +1150,6 @@ SDL_DYNAPI_PROC(void,SDL_GpuDispatchComputeIndirect,(SDL_GpuComputePass *a, SDL_
 SDL_DYNAPI_PROC(void,SDL_GpuEndComputePass,(SDL_GpuComputePass *a),(a),)
 SDL_DYNAPI_PROC(void,SDL_GpuMapTransferBuffer,(SDL_GpuDevice *a, SDL_GpuTransferBuffer *b, SDL_bool c, void **d),(a,b,c,d),)
 SDL_DYNAPI_PROC(void,SDL_GpuUnmapTransferBuffer,(SDL_GpuDevice *a, SDL_GpuTransferBuffer *b),(a,b),)
-SDL_DYNAPI_PROC(void,SDL_GpuSetTransferData,(SDL_GpuDevice *a, const void *b, SDL_GpuTransferBufferRegion *c, SDL_bool d),(a,b,c,d),)
-SDL_DYNAPI_PROC(void,SDL_GpuGetTransferData,(SDL_GpuDevice *a, SDL_GpuTransferBufferRegion *b, void *c),(a,b,c),)
 SDL_DYNAPI_PROC(SDL_GpuCopyPass*,SDL_GpuBeginCopyPass,(SDL_GpuCommandBuffer *a),(a),return)
 SDL_DYNAPI_PROC(void,SDL_GpuUploadToTexture,(SDL_GpuCopyPass *a, SDL_GpuTextureTransferInfo *b, SDL_GpuTextureRegion *c, SDL_bool d),(a,b,c,d),)
 SDL_DYNAPI_PROC(void,SDL_GpuUploadToBuffer,(SDL_GpuCopyPass *a, SDL_GpuTransferBufferLocation *b, SDL_GpuBufferRegion *c, SDL_bool d),(a,b,c,d),)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1520,50 +1520,6 @@ void SDL_GpuUnmapTransferBuffer(
         transferBuffer);
 }
 
-void SDL_GpuSetTransferData(
-    SDL_GpuDevice *device,
-    const void *source,
-    SDL_GpuTransferBufferRegion *destination,
-    SDL_bool cycle)
-{
-    CHECK_DEVICE_MAGIC(device, );
-    if (source == NULL) {
-        SDL_InvalidParamError("source");
-        return;
-    }
-    if (destination == NULL) {
-        SDL_InvalidParamError("destination");
-        return;
-    }
-
-    device->SetTransferData(
-        device->driverData,
-        source,
-        destination,
-        cycle);
-}
-
-void SDL_GpuGetTransferData(
-    SDL_GpuDevice *device,
-    SDL_GpuTransferBufferRegion *source,
-    void *destination)
-{
-    CHECK_DEVICE_MAGIC(device, );
-    if (source == NULL) {
-        SDL_InvalidParamError("source");
-        return;
-    }
-    if (destination == NULL) {
-        SDL_InvalidParamError("destination");
-        return;
-    }
-
-    device->GetTransferData(
-        device->driverData,
-        source,
-        destination);
-}
-
 /* Copy Pass */
 
 SDL_GpuCopyPass *SDL_GpuBeginCopyPass(

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -435,17 +435,6 @@ struct SDL_GpuDevice
         SDL_GpuRenderer *device,
         SDL_GpuTransferBuffer *transferBuffer);
 
-    void (*SetTransferData)(
-        SDL_GpuRenderer *driverData,
-        const void *source,
-        SDL_GpuTransferBufferRegion *destination,
-        SDL_bool cycle);
-
-    void (*GetTransferData)(
-        SDL_GpuRenderer *driverData,
-        SDL_GpuTransferBufferRegion *source,
-        void *destination);
-
     /* Copy Pass */
 
     void (*BeginCopyPass)(
@@ -642,8 +631,6 @@ struct SDL_GpuDevice
     ASSIGN_DRIVER_FUNC(EndComputePass, name)                \
     ASSIGN_DRIVER_FUNC(MapTransferBuffer, name)             \
     ASSIGN_DRIVER_FUNC(UnmapTransferBuffer, name)           \
-    ASSIGN_DRIVER_FUNC(SetTransferData, name)               \
-    ASSIGN_DRIVER_FUNC(GetTransferData, name)               \
     ASSIGN_DRIVER_FUNC(BeginCopyPass, name)                 \
     ASSIGN_DRIVER_FUNC(UploadToTexture, name)               \
     ASSIGN_DRIVER_FUNC(UploadToBuffer, name)                \

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -2709,39 +2709,6 @@ static void D3D11_UnmapTransferBuffer(
     (void)transferBuffer;
 }
 
-static void D3D11_SetTransferData(
-    SDL_GpuRenderer *driverData,
-    const void *source,
-    SDL_GpuTransferBufferRegion *destination,
-    SDL_bool cycle)
-{
-    D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)destination->transferBuffer;
-    void *dataPtr;
-
-    D3D11_MapTransferBuffer(driverData, destination->transferBuffer, cycle, &dataPtr);
-
-    SDL_memcpy(
-        ((Uint8 *)container->activeBuffer->data) + destination->offset,
-        source,
-        destination->size);
-
-    D3D11_UnmapTransferBuffer(driverData, destination->transferBuffer);
-}
-
-static void D3D11_GetTransferData(
-    SDL_GpuRenderer *driverData,
-    SDL_GpuTransferBufferRegion *source,
-    void *destination)
-{
-    (void)driverData;
-    D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)source->transferBuffer;
-
-    SDL_memcpy(
-        destination,
-        ((Uint8 *)container->activeBuffer->data) + source->offset,
-        source->size);
-}
-
 /* Copy Pass */
 
 static void D3D11_BeginCopyPass(

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -4945,33 +4945,6 @@ static void D3D12_UnmapTransferBuffer(
     }
 }
 
-static void D3D12_SetTransferData(
-    SDL_GpuRenderer *driverData,
-    const void *source,
-    SDL_GpuTransferBufferRegion *destination,
-    SDL_bool cycle)
-{
-    D3D12BufferContainer *container = (D3D12BufferContainer *)destination->transferBuffer;
-    void *dataPtr;
-
-    D3D12_MapTransferBuffer(driverData, destination->transferBuffer, cycle, &dataPtr);
-
-    SDL_memcpy(
-        ((Uint8 *)container->activeBuffer->mapPointer) + destination->offset,
-        source,
-        destination->size);
-
-    D3D12_UnmapTransferBuffer(driverData, destination->transferBuffer);
-}
-
-static void D3D12_GetTransferData(
-    SDL_GpuRenderer *driverData,
-    SDL_GpuTransferBufferRegion *source,
-    void *destination)
-{
-    SDL_assert(SDL_FALSE);
-}
-
 /* Copy Pass */
 
 static void D3D12_BeginCopyPass(

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1659,45 +1659,6 @@ static void METAL_UnmapTransferBuffer(
 #endif
 }
 
-static void METAL_SetTransferData(
-    SDL_GpuRenderer *driverData,
-    const void *source,
-    SDL_GpuTransferBufferRegion *destination,
-    SDL_bool cycle)
-{
-    @autoreleasepool {
-        MetalRenderer *renderer = (MetalRenderer *)driverData;
-        MetalBufferContainer *container = (MetalBufferContainer *)destination->transferBuffer;
-        MetalBuffer *buffer = METAL_INTERNAL_PrepareBufferForWrite(renderer, container, cycle);
-
-        SDL_memcpy(
-            ((Uint8 *)buffer->handle.contents) + destination->offset,
-            ((Uint8 *)source),
-            destination->size);
-
-#ifdef SDL_PLATFORM_MACOS
-        /* FIXME: Is this necessary? */
-        if (buffer->handle.storageMode == MTLStorageModeManaged) {
-            [buffer->handle didModifyRange:NSMakeRange(destination->offset, destination->size)];
-        }
-#endif
-    }
-}
-
-static void METAL_GetTransferData(
-    SDL_GpuRenderer *driverData,
-    SDL_GpuTransferBufferRegion *source,
-    void *destination)
-{
-    @autoreleasepool {
-        MetalBufferContainer *transferBufferContainer = (MetalBufferContainer *)source->transferBuffer;
-        SDL_memcpy(
-            ((Uint8 *)destination),
-            ((Uint8 *)transferBufferContainer->activeBuffer->handle.contents) + source->offset,
-            source->size);
-    }
-}
-
 /* Copy Pass */
 
 static void METAL_BeginCopyPass(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -8694,48 +8694,6 @@ static void VULKAN_UnmapTransferBuffer(
     (void)transferBuffer;
 }
 
-static void VULKAN_SetTransferData(
-    SDL_GpuRenderer *driverData,
-    const void *source,
-    SDL_GpuTransferBufferRegion *destination,
-    SDL_bool cycle)
-{
-    VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination->transferBuffer;
-
-    if (
-        cycle &&
-        SDL_AtomicGet(&transferBufferContainer->activeBufferHandle->vulkanBuffer->referenceCount) > 0) {
-        VULKAN_INTERNAL_CycleActiveBuffer(
-            renderer,
-            transferBufferContainer);
-    }
-
-    Uint8 *bufferPointer =
-        transferBufferContainer->activeBufferHandle->vulkanBuffer->usedRegion->allocation->mapPointer +
-        transferBufferContainer->activeBufferHandle->vulkanBuffer->usedRegion->resourceOffset +
-        destination->offset;
-
-    SDL_memcpy(bufferPointer, source, destination->size);
-}
-
-static void VULKAN_GetTransferData(
-    SDL_GpuRenderer *driverData,
-    SDL_GpuTransferBufferRegion *source,
-    void *destination)
-{
-    (void)driverData; /* used by other backends */
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transferBuffer;
-    VulkanBuffer *vulkanBuffer = transferBufferContainer->activeBufferHandle->vulkanBuffer;
-
-    Uint8 *bufferPointer =
-        vulkanBuffer->usedRegion->allocation->mapPointer +
-        vulkanBuffer->usedRegion->resourceOffset +
-        source->offset;
-
-    SDL_memcpy(destination, bufferPointer, source->size);
-}
-
 static void VULKAN_BeginCopyPass(
     SDL_GpuCommandBuffer *commandBuffer)
 {

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -388,7 +388,7 @@ Render(SDL_Window *window, const int windownum)
     pass = SDL_GpuBeginRenderPass(cmd, &color_attachment, 1, &depth_attachment);
     SDL_GpuBindGraphicsPipeline(pass, render_state.pipeline);
     SDL_GpuBindVertexBuffers(pass, 0, &vertex_binding, 1);
-    SDL_GpuDrawPrimitives(pass, 0, 12);
+    SDL_GpuDrawPrimitives(pass, 0, 36);
     SDL_GpuEndRenderPass(pass);
 
     /* Blit MSAA to swapchain, if needed */
@@ -452,7 +452,7 @@ init_render_state(int msaa)
 {
     SDL_GpuCommandBuffer *cmd;
     SDL_GpuTransferBuffer *buf_transfer;
-    SDL_GpuTransferBufferRegion buf_region;
+    void *map;
     SDL_GpuTransferBufferLocation buf_location;
     SDL_GpuBufferRegion dst_region;
     SDL_GpuCopyPass *copy_pass;
@@ -505,10 +505,9 @@ init_render_state(int msaa)
     CHECK_CREATE(buf_transfer, "Vertex transfer buffer")
 
     /* We just need to upload the static data once. */
-    buf_region.transferBuffer = buf_transfer;
-    buf_region.offset = 0;
-    buf_region.size = sizeof(vertex_data);
-    SDL_GpuSetTransferData(gpu_device, (void*) vertex_data, &buf_region, SDL_FALSE);
+    SDL_GpuMapTransferBuffer(gpu_device, buf_transfer, SDL_FALSE, &map);
+    SDL_memcpy(map, vertex_data, sizeof(vertex_data));
+    SDL_GpuUnmapTransferBuffer(gpu_device, buf_transfer);
 
     cmd = SDL_GpuAcquireCommandBuffer(gpu_device);
     copy_pass = SDL_GpuBeginCopyPass(cmd);


### PR DESCRIPTION
Removing these in favor of Map/Unmap. Incidentally this also lets us remove the SDL_GpuTransferBufferRegion struct since it was used exclusively for these functions.
