### PR TITLE
Relax bind order requirement and unset bound state on pass end

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -55,10 +55,22 @@
         return;                                              \
     }
 
+#define CHECK_GRAPHICS_PIPELINE_BOUND                                                       \
+    if (!((CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER)->graphicsPipelineBound) { \
+        SDL_assert_release(!"Graphics pipeline not bound!");                                \
+        return;                                                                             \
+    }
+
 #define CHECK_COMPUTEPASS                                     \
     if (!((Pass *)computePass)->inProgress) {                 \
         SDL_assert_release(!"Compute pass not in progress!"); \
         return;                                               \
+    }
+
+#define CHECK_COMPUTE_PIPELINE_BOUND                                                        \
+    if (!((CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER)->computePipelineBound) { \
+        SDL_assert_release(!"Compute pipeline not bound!");                                 \
+        return;                                                                             \
     }
 
 #define CHECK_COPYPASS                                     \
@@ -1160,6 +1172,7 @@ void SDL_GpuDrawIndexedPrimitives(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
+        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawIndexedPrimitives(
@@ -1182,6 +1195,7 @@ void SDL_GpuDrawPrimitives(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
+        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawPrimitives(
@@ -1208,6 +1222,7 @@ void SDL_GpuDrawPrimitivesIndirect(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
+        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawPrimitivesIndirect(
@@ -1236,6 +1251,7 @@ void SDL_GpuDrawIndexedPrimitivesIndirect(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
+        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawIndexedPrimitivesIndirect(
@@ -1408,6 +1424,7 @@ void SDL_GpuDispatchCompute(
 
     if (COMPUTEPASS_DEVICE->debugMode) {
         CHECK_COMPUTEPASS
+        CHECK_COMPUTE_PIPELINE_BOUND
     }
 
     COMPUTEPASS_DEVICE->DispatchCompute(
@@ -1429,6 +1446,7 @@ void SDL_GpuDispatchComputeIndirect(
 
     if (COMPUTEPASS_DEVICE->debugMode) {
         CHECK_COMPUTEPASS
+        CHECK_COMPUTE_PIPELINE_BOUND
     }
 
     COMPUTEPASS_DEVICE->DispatchComputeIndirect(

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -55,22 +55,10 @@
         return;                                              \
     }
 
-#define CHECK_GRAPHICS_PIPELINE_BOUND                                                       \
-    if (!((CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER)->graphicsPipelineBound) { \
-        SDL_assert_release(!"Graphics pipeline not bound!");                                \
-        return;                                                                             \
-    }
-
 #define CHECK_COMPUTEPASS                                     \
     if (!((Pass *)computePass)->inProgress) {                 \
         SDL_assert_release(!"Compute pass not in progress!"); \
         return;                                               \
-    }
-
-#define CHECK_COMPUTE_PIPELINE_BOUND                                                        \
-    if (!((CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER)->computePipelineBound) { \
-        SDL_assert_release(!"Compute pipeline not bound!");                                 \
-        return;                                                                             \
     }
 
 #define CHECK_COPYPASS                                     \
@@ -969,7 +957,6 @@ void SDL_GpuBindVertexBuffers(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindVertexBuffers(
@@ -995,7 +982,6 @@ void SDL_GpuBindIndexBuffer(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindIndexBuffer(
@@ -1021,7 +1007,6 @@ void SDL_GpuBindVertexSamplers(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindVertexSamplers(
@@ -1048,7 +1033,6 @@ void SDL_GpuBindVertexStorageTextures(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindVertexStorageTextures(
@@ -1075,7 +1059,6 @@ void SDL_GpuBindVertexStorageBuffers(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindVertexStorageBuffers(
@@ -1102,7 +1085,6 @@ void SDL_GpuBindFragmentSamplers(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindFragmentSamplers(
@@ -1129,7 +1111,6 @@ void SDL_GpuBindFragmentStorageTextures(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindFragmentStorageTextures(
@@ -1156,7 +1137,6 @@ void SDL_GpuBindFragmentStorageBuffers(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->BindFragmentStorageBuffers(
@@ -1180,7 +1160,6 @@ void SDL_GpuDrawIndexedPrimitives(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawIndexedPrimitives(
@@ -1203,7 +1182,6 @@ void SDL_GpuDrawPrimitives(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawPrimitives(
@@ -1230,7 +1208,6 @@ void SDL_GpuDrawPrimitivesIndirect(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawPrimitivesIndirect(
@@ -1259,7 +1236,6 @@ void SDL_GpuDrawIndexedPrimitivesIndirect(
 
     if (RENDERPASS_DEVICE->debugMode) {
         CHECK_RENDERPASS
-        CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawIndexedPrimitivesIndirect(
@@ -1384,7 +1360,6 @@ void SDL_GpuBindComputeStorageTextures(
 
     if (COMPUTEPASS_DEVICE->debugMode) {
         CHECK_COMPUTEPASS
-        CHECK_COMPUTE_PIPELINE_BOUND
     }
 
     COMPUTEPASS_DEVICE->BindComputeStorageTextures(
@@ -1411,7 +1386,6 @@ void SDL_GpuBindComputeStorageBuffers(
 
     if (COMPUTEPASS_DEVICE->debugMode) {
         CHECK_COMPUTEPASS
-        CHECK_COMPUTE_PIPELINE_BOUND
     }
 
     COMPUTEPASS_DEVICE->BindComputeStorageBuffers(
@@ -1434,7 +1408,6 @@ void SDL_GpuDispatchCompute(
 
     if (COMPUTEPASS_DEVICE->debugMode) {
         CHECK_COMPUTEPASS
-        CHECK_COMPUTE_PIPELINE_BOUND
     }
 
     COMPUTEPASS_DEVICE->DispatchCompute(
@@ -1456,7 +1429,6 @@ void SDL_GpuDispatchComputeIndirect(
 
     if (COMPUTEPASS_DEVICE->debugMode) {
         CHECK_COMPUTEPASS
-        CHECK_COMPUTE_PIPELINE_BOUND
     }
 
     COMPUTEPASS_DEVICE->DispatchComputeIndirect(

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -596,6 +596,8 @@ typedef struct D3D11CommandBuffer
 
     /* Resource slot state */
 
+    SDL_bool needVertexBufferBind;
+
     SDL_bool needVertexSamplerBind;
     SDL_bool needVertexResourceBind;
     SDL_bool needVertexUniformBufferBind;
@@ -607,6 +609,10 @@ typedef struct D3D11CommandBuffer
     SDL_bool needComputeUAVBind;
     SDL_bool needComputeSRVBind;
     SDL_bool needComputeUniformBufferBind;
+
+    ID3D11Buffer *vertexBuffers[MAX_BUFFER_BINDINGS];
+    Uint32 vertexBufferOffsets[MAX_BUFFER_BINDINGS];
+    Uint32 vertexBufferCount;
 
     ID3D11SamplerState *vertexSamplers[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     ID3D11ShaderResourceView *vertexShaderResourceViews[MAX_TEXTURE_SAMPLERS_PER_STAGE +
@@ -3637,23 +3643,18 @@ static void D3D11_BindVertexBuffers(
     Uint32 bindingCount)
 {
     D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
-    ID3D11Buffer *bufferHandles[MAX_BUFFER_BINDINGS];
-    UINT bufferOffsets[MAX_BUFFER_BINDINGS];
 
     for (Uint32 i = 0; i < bindingCount; i += 1) {
         D3D11Buffer *currentBuffer = ((D3D11BufferContainer *)pBindings[i].buffer)->activeBuffer;
-        bufferHandles[i] = currentBuffer->handle;
-        bufferOffsets[i] = pBindings[i].offset;
+        d3d11CommandBuffer->vertexBuffers[firstBinding + i] = currentBuffer->handle;
+        d3d11CommandBuffer->vertexBufferOffsets[firstBinding + i] = pBindings[i].offset;
         D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, currentBuffer);
     }
 
-    ID3D11DeviceContext_IASetVertexBuffers(
-        d3d11CommandBuffer->context,
-        firstBinding,
-        bindingCount,
-        bufferHandles,
-        &d3d11CommandBuffer->graphicsPipeline->vertexStrides[firstBinding],
-        bufferOffsets);
+    d3d11CommandBuffer->vertexBufferCount =
+        SDL_max(d3d11CommandBuffer->vertexBufferCount, firstBinding + bindingCount);
+
+    d3d11CommandBuffer->needVertexBufferBind = SDL_TRUE;
 }
 
 static void D3D11_BindIndexBuffer(
@@ -3858,6 +3859,16 @@ static void D3D11_INTERNAL_BindGraphicsResources(
 
     ID3D11Buffer *nullBuf = NULL;
     Uint32 offsetInConstants, blockSizeInConstants, i;
+
+    if (commandBuffer->needVertexBufferBind) {
+        ID3D11DeviceContext_IASetVertexBuffers(
+            commandBuffer->context,
+            0,
+            commandBuffer->vertexBufferCount,
+            commandBuffer->vertexBuffers,
+            graphicsPipeline->vertexStrides,
+            commandBuffer->vertexBufferOffsets);
+    }
 
     if (commandBuffer->needVertexSamplerBind) {
         if (graphicsPipeline->vertexSamplerCount > 0) {
@@ -4071,6 +4082,10 @@ static void D3D11_EndRenderPass(
     }
 
     /* Reset bind state */
+    SDL_zeroa(d3d11CommandBuffer->vertexBuffers);
+    SDL_zeroa(d3d11CommandBuffer->vertexBufferOffsets);
+    d3d11CommandBuffer->vertexBufferCount = 0;
+
     SDL_zeroa(d3d11CommandBuffer->vertexSamplers);
     SDL_zeroa(d3d11CommandBuffer->vertexShaderResourceViews);
 

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -4069,6 +4069,13 @@ static void D3D11_EndRenderPass(
                 d3d11CommandBuffer->colorTargetMsaaFormat[i]);
         }
     }
+
+    /* Reset bind state */
+    SDL_zeroa(d3d11CommandBuffer->vertexSamplers);
+    SDL_zeroa(d3d11CommandBuffer->vertexShaderResourceViews);
+
+    SDL_zeroa(d3d11CommandBuffer->fragmentSamplers);
+    SDL_zeroa(d3d11CommandBuffer->fragmentShaderResourceViews);
 }
 
 static void D3D11_PushVertexUniformData(
@@ -4454,6 +4461,10 @@ static void D3D11_EndComputePass(
         NULL);
 
     d3d11CommandBuffer->computePipeline = NULL;
+
+    /* Reset bind state */
+    SDL_zeroa(d3d11CommandBuffer->computeUnorderedAccessViews);
+    SDL_zeroa(d3d11CommandBuffer->computeShaderResourceViews);
 }
 
 /* Fence Cleanup */

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -616,7 +616,7 @@ struct D3D12CommandBuffer
 
     D3D12Texture *fragmentSamplerTextures[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     D3D12Sampler *fragmentSamplers[MAX_TEXTURE_SAMPLERS_PER_STAGE];
-    D3D12TextureSubresource *fragmentStorageTextureSlices[MAX_STORAGE_TEXTURES_PER_STAGE];
+    D3D12TextureSubresource *fragmentStorageTextureSubresources[MAX_STORAGE_TEXTURES_PER_STAGE];
     D3D12Buffer *fragmentStorageBuffers[MAX_STORAGE_BUFFERS_PER_STAGE];
     D3D12UniformBuffer *fragmentUniformBuffers[MAX_UNIFORM_BUFFERS_PER_STAGE];
 
@@ -4246,7 +4246,7 @@ static void D3D12_BindFragmentStorageTextures(
 
         D3D12_INTERNAL_TrackTextureSubresource(d3d12CommandBuffer, subresource);
 
-        d3d12CommandBuffer->fragmentStorageTextureSlices[firstSlot + i] = subresource;
+        d3d12CommandBuffer->fragmentStorageTextureSubresources[firstSlot + i] = subresource;
     }
 
     d3d12CommandBuffer->needFragmentStorageTextureBind = SDL_TRUE;
@@ -4471,7 +4471,7 @@ static void D3D12_INTERNAL_BindGraphicsResources(
     if (commandBuffer->needFragmentStorageTextureBind) {
         if (graphicsPipeline->fragmentStorageTextureCount > 0) {
             for (Uint32 i = 0; i < graphicsPipeline->fragmentStorageTextureCount; i += 1) {
-                cpuHandles[i] = commandBuffer->fragmentStorageTextureSlices[i]->srvHandle.cpuHandle;
+                cpuHandles[i] = commandBuffer->fragmentStorageTextureSubresources[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
@@ -4636,6 +4636,20 @@ static void D3D12_EndRenderPass(
         NULL,
         SDL_FALSE,
         NULL);
+
+    /* Reset bind state */
+    SDL_zeroa(d3d12CommandBuffer->colorAttachmentTextureSubresources);
+    d3d12CommandBuffer->depthStencilTextureSubresource = NULL;
+
+    SDL_zeroa(d3d12CommandBuffer->vertexSamplerTextures);
+    SDL_zeroa(d3d12CommandBuffer->vertexSamplers);
+    SDL_zeroa(d3d12CommandBuffer->vertexStorageTextureSubresources);
+    SDL_zeroa(d3d12CommandBuffer->vertexStorageBuffers);
+
+    SDL_zeroa(d3d12CommandBuffer->fragmentSamplerTextures);
+    SDL_zeroa(d3d12CommandBuffer->fragmentSamplers);
+    SDL_zeroa(d3d12CommandBuffer->fragmentStorageTextureSubresources);
+    SDL_zeroa(d3d12CommandBuffer->fragmentStorageBuffers);
 }
 
 /* Compute Pass */
@@ -4962,7 +4976,7 @@ static void D3D12_EndComputePass(
 {
     D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < MAX_COMPUTE_WRITE_TEXTURES; i += 1) {
+    for (Uint32 i = 0; i < d3d12CommandBuffer->computeReadWriteStorageTextureCount; i += 1) {
         if (d3d12CommandBuffer->computeReadWriteStorageTextures[i]) {
             D3D12_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
                 d3d12CommandBuffer,
@@ -4973,7 +4987,7 @@ static void D3D12_EndComputePass(
         }
     }
 
-    for (Uint32 i = 0; i < MAX_COMPUTE_WRITE_BUFFERS; i += 1) {
+    for (Uint32 i = 0; i < d3d12CommandBuffer->computeReadWriteStorageBufferCount; i += 1) {
         if (d3d12CommandBuffer->computeReadWriteStorageBuffers[i]) {
             D3D12_INTERNAL_BufferTransitionToDefaultUsage(
                 d3d12CommandBuffer,
@@ -6455,7 +6469,7 @@ static SDL_GpuCommandBuffer *D3D12_AcquireCommandBuffer(
 
     SDL_zeroa(commandBuffer->fragmentSamplerTextures);
     SDL_zeroa(commandBuffer->fragmentSamplers);
-    SDL_zeroa(commandBuffer->fragmentStorageTextureSlices);
+    SDL_zeroa(commandBuffer->fragmentStorageTextureSubresources);
     SDL_zeroa(commandBuffer->fragmentStorageBuffers);
     SDL_zeroa(commandBuffer->fragmentUniformBuffers);
 

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2758,18 +2758,18 @@ static void METAL_EndRenderPass(
         metalCommandBuffer->renderEncoder = nil;
 
         for (Uint32 i = 0; i < MAX_TEXTURE_SAMPLERS_PER_STAGE; i += 1) {
-            commandBuffer->vertexSamplers[i] = nil;
-            commandBuffer->vertexTextures[i] = nil;
-            commandBuffer->fragmentSamplers[i] = nil;
-            commandBuffer->fragmentTextures[i] = nil;
+            metalCommandBuffer->vertexSamplers[i] = nil;
+            metalCommandBuffer->vertexTextures[i] = nil;
+            metalCommandBuffer->fragmentSamplers[i] = nil;
+            metalCommandBuffer->fragmentTextures[i] = nil;
         }
         for (Uint32 i = 0; i < MAX_STORAGE_TEXTURES_PER_STAGE; i += 1) {
-            commandBuffer->vertexStorageTextures[i] = nil;
-            commandBuffer->fragmentStorageTextures[i] = nil;
+            metalCommandBuffer->vertexStorageTextures[i] = nil;
+            metalCommandBuffer->fragmentStorageTextures[i] = nil;
         }
         for (Uint32 i = 0; i < MAX_STORAGE_BUFFERS_PER_STAGE; i += 1) {
-            commandBuffer->vertexStorageBuffers[i] = nil;
-            commandBuffer->fragmentStorageBuffers[i] = nil;
+            metalCommandBuffer->vertexStorageBuffers[i] = nil;
+            metalCommandBuffer->fragmentStorageBuffers[i] = nil;
         }
     }
 }

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2756,6 +2756,16 @@ static void METAL_EndRenderPass(
         MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         [metalCommandBuffer->renderEncoder endEncoding];
         metalCommandBuffer->renderEncoder = nil;
+
+        SDL_zeroa(metalCommandBuffer->vertexSamplers);
+        SDL_zeroa(metalCommandBuffer->vertexTextures);
+        SDL_zeroa(metalCommandBuffer->vertexStorageTextures);
+        SDL_zeroa(metalCommandBuffer->vertexStorageBuffers);
+
+        SDL_zeroa(metalCommandBuffer->fragmentSamplers);
+        SDL_zeroa(metalCommandBuffer->fragmentTextures);
+        SDL_zeroa(metalCommandBuffer->fragmentStorageTextures);
+        SDL_zeroa(metalCommandBuffer->fragmentStorageBuffers);
     }
 }
 
@@ -3204,6 +3214,11 @@ static void METAL_EndComputePass(
         MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         [metalCommandBuffer->computeEncoder endEncoding];
         metalCommandBuffer->computeEncoder = nil;
+
+        SDL_zeroa(metalCommandBuffer->computeReadOnlyTextures);
+        SDL_zeroa(metalCommandBuffer->computeReadOnlyBuffers);
+        SDL_zeroa(metalCommandBuffer->computeReadWriteTextures);
+        SDL_zeroa(metalCommandBuffer->computeReadWriteBuffers);
     }
 }
 

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2757,15 +2757,20 @@ static void METAL_EndRenderPass(
         [metalCommandBuffer->renderEncoder endEncoding];
         metalCommandBuffer->renderEncoder = nil;
 
-        SDL_zeroa(metalCommandBuffer->vertexSamplers);
-        SDL_zeroa(metalCommandBuffer->vertexTextures);
-        SDL_zeroa(metalCommandBuffer->vertexStorageTextures);
-        SDL_zeroa(metalCommandBuffer->vertexStorageBuffers);
-
-        SDL_zeroa(metalCommandBuffer->fragmentSamplers);
-        SDL_zeroa(metalCommandBuffer->fragmentTextures);
-        SDL_zeroa(metalCommandBuffer->fragmentStorageTextures);
-        SDL_zeroa(metalCommandBuffer->fragmentStorageBuffers);
+        for (Uint32 i = 0; i < MAX_TEXTURE_SAMPLERS_PER_STAGE; i += 1) {
+            commandBuffer->vertexSamplers[i] = nil;
+            commandBuffer->vertexTextures[i] = nil;
+            commandBuffer->fragmentSamplers[i] = nil;
+            commandBuffer->fragmentTextures[i] = nil;
+        }
+        for (Uint32 i = 0; i < MAX_STORAGE_TEXTURES_PER_STAGE; i += 1) {
+            commandBuffer->vertexStorageTextures[i] = nil;
+            commandBuffer->fragmentStorageTextures[i] = nil;
+        }
+        for (Uint32 i = 0; i < MAX_STORAGE_BUFFERS_PER_STAGE; i += 1) {
+            commandBuffer->vertexStorageBuffers[i] = nil;
+            commandBuffer->fragmentStorageBuffers[i] = nil;
+        }
     }
 }
 
@@ -3215,10 +3220,18 @@ static void METAL_EndComputePass(
         [metalCommandBuffer->computeEncoder endEncoding];
         metalCommandBuffer->computeEncoder = nil;
 
-        SDL_zeroa(metalCommandBuffer->computeReadOnlyTextures);
-        SDL_zeroa(metalCommandBuffer->computeReadOnlyBuffers);
-        SDL_zeroa(metalCommandBuffer->computeReadWriteTextures);
-        SDL_zeroa(metalCommandBuffer->computeReadWriteBuffers);
+        for (Uint32 i = 0; i < MAX_COMPUTE_WRITE_TEXTURES; i += 1) {
+            metalCommandBuffer->computeReadWriteTextures[i] = nil;
+        }
+        for (Uint32 i = 0; i < MAX_COMPUTE_WRITE_BUFFERS; i += 1) {
+            metalCommandBuffer->computeReadWriteBuffers[i] = nil;
+        }
+        for (Uint32 i = 0; i < MAX_STORAGE_TEXTURES_PER_STAGE; i += 1) {
+            metalCommandBuffer->computeReadOnlyTextures[i] = nil;
+        }
+        for (Uint32 i = 0; i < MAX_STORAGE_BUFFERS_PER_STAGE; i += 1) {
+            metalCommandBuffer->computeReadOnlyBuffers[i] = nil;
+        }
     }
 }
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -8133,6 +8133,20 @@ static void VULKAN_EndRenderPass(
     vulkanCommandBuffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
     vulkanCommandBuffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
     vulkanCommandBuffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
+
+    /* Reset bind state */
+    SDL_zeroa(vulkanCommandBuffer->colorAttachmentSlices);
+    vulkanCommandBuffer->depthStencilAttachmentSlice = NULL;
+
+    SDL_zeroa(vulkanCommandBuffer->vertexSamplers);
+    SDL_zeroa(vulkanCommandBuffer->vertexSamplerTextures);
+    SDL_zeroa(vulkanCommandBuffer->vertexStorageTextureSlices);
+    SDL_zeroa(vulkanCommandBuffer->vertexStorageBuffers);
+
+    SDL_zeroa(vulkanCommandBuffer->fragmentSamplers);
+    SDL_zeroa(vulkanCommandBuffer->fragmentSamplerTextures);
+    SDL_zeroa(vulkanCommandBuffer->fragmentStorageTextureSlices);
+    SDL_zeroa(vulkanCommandBuffer->fragmentStorageBuffers);
 }
 
 static void VULKAN_BeginComputePass(


### PR DESCRIPTION
Merge #175 before this one. Resolves #117 and #134. 

You no longer have to bind a pipeline before binding graphics or compute resources. 

Bound graphics state is now explicitly unset on EndRenderPass and EndComputePass. Note that uniform buffers are an exception because those are managed internally and not bound by the client.