### PR TITLE
[GPU] Only select drivers with supported shader formats

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -140,6 +140,10 @@ static SDL_GpuDriver SDL_GpuSelectBackend(
     }
 
     for (i = 0; backends[i]; i += 1) {
+        if ((backends[i]->shaderFormats & formatFlags) == 0) {
+            /* Don't select a backend which doesn't support the app's shaders. */
+            continue;
+        }
         if (backends[i]->PrepareDriver(_this)) {
             return backends[i]->backendflag;
         }


### PR DESCRIPTION
Currently, SDL will choose the default driver if no driver name is passed to ``SDL_GpuCreateDevice()``, even if it doesn't support the listed shader formats. This then invariably results in the device being useless, and the program either noticing this and quitting, or eventually hitting an "Incompatible shader format for GPU backend" assertion.

Instead, let's just remove any incompatible devices from the list. This does require users to actually provide the correct list of supported shader formats properly, lest they don't get a device, but that's probably a good thing.

As of #199, we do a similar check (and log an error) if a specific driver has been requested, but the shader formats don't match. This is basically just extending that to the default selection (without the log message).

(I'm assuming this was the intended behaviour all along, and either something broke it, or it's being delayed for now as a not-so-subtle encouragement to get people to actually write shaders for more than one backend.)