### PR TITLE
Consolidate layerCount and depth

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -550,15 +550,14 @@ typedef struct SDL_GpuShaderCreateInfo
 
 typedef struct SDL_GpuTextureCreateInfo
 {
-    Uint32 width;
-    Uint32 height;
-    Uint32 depth;
     SDL_GpuTextureType type;
-    Uint32 layerCount;
-    Uint32 levelCount;
-    SDL_GpuSampleCount sampleCount;
     SDL_GpuTextureFormat format;
     SDL_GpuTextureUsageFlags usageFlags;
+    Uint32 width;
+    Uint32 height;
+    Uint32 layerCountOrDepth;
+    Uint32 levelCount;
+    SDL_GpuSampleCount sampleCount;
 
     SDL_PropertiesID props;
 } SDL_GpuTextureCreateInfo;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1288,10 +1288,10 @@ static MetalTexture *METAL_INTERNAL_CreateTexture(
 
     textureDescriptor.width = textureCreateInfo->width;
     textureDescriptor.height = textureCreateInfo->height;
-    textureDescriptor.depth = textureCreateInfo->depth;
+    textureDescriptor.depth = (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D) ? textureCreateInfo->layerCountOrDepth : 1;
     textureDescriptor.mipmapLevelCount = textureCreateInfo->levelCount;
     textureDescriptor.sampleCount = 1;
-    textureDescriptor.arrayLength = (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) ? textureCreateInfo->layerCount : 1;
+    textureDescriptor.arrayLength = (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) ? textureCreateInfo->layerCountOrDepth : 1;
     textureDescriptor.storageMode = MTLStorageModePrivate;
 
     textureDescriptor.usage = 0;
@@ -3381,7 +3381,7 @@ static Uint8 METAL_INTERNAL_CreateSwapchain(
     windowData->textureContainer.textureCount = 1;
     windowData->textureContainer.header.info.format = SwapchainCompositionToFormat[swapchainComposition];
     windowData->textureContainer.header.info.levelCount = 1;
-    windowData->textureContainer.header.info.depth = 1;
+    windowData->textureContainer.header.info.layerCountOrDepth = 1;
     windowData->textureContainer.header.info.type = SDL_GPU_TEXTURETYPE_2D;
     windowData->textureContainer.header.info.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET_BIT;
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4695,12 +4695,11 @@ static SDL_bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->textureContainers[i].canBeCycled = SDL_FALSE;
         swapchainData->textureContainers[i].header.info.width = drawableWidth;
         swapchainData->textureContainers[i].header.info.height = drawableHeight;
-        swapchainData->textureContainers[i].header.info.depth = 1;
+        swapchainData->textureContainers[i].header.info.layerCountOrDepth = 1;
         swapchainData->textureContainers[i].header.info.format = SwapchainCompositionToSDLFormat(
             windowData->swapchainComposition,
             swapchainData->usingFallbackFormat);
         swapchainData->textureContainers[i].header.info.type = SDL_GPU_TEXTURETYPE_2D;
-        swapchainData->textureContainers[i].header.info.layerCount = 1;
         swapchainData->textureContainers[i].header.info.levelCount = 1;
         swapchainData->textureContainers[i].header.info.sampleCount = SDL_GPU_SAMPLECOUNT_1;
         swapchainData->textureContainers[i].header.info.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET_BIT;
@@ -6980,9 +6979,9 @@ static SDL_GpuTexture *VULKAN_CreateTexture(
         renderer,
         textureCreateInfo->width,
         textureCreateInfo->height,
-        textureCreateInfo->depth,
+        textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D ? textureCreateInfo->layerCountOrDepth : 1,
         textureCreateInfo->type,
-        textureCreateInfo->layerCount,
+        textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : textureCreateInfo->layerCountOrDepth,
         textureCreateInfo->levelCount,
         SDLToVK_SampleCount[actualSampleCount],
         format,

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -256,8 +256,7 @@ CreateDepthTexture(Uint32 drawablew, Uint32 drawableh)
     depthtex_createinfo.format = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
     depthtex_createinfo.width = drawablew;
     depthtex_createinfo.height = drawableh;
-    depthtex_createinfo.depth = 1;
-    depthtex_createinfo.layerCount = 1;
+    depthtex_createinfo.layerCountOrDepth = 1;
     depthtex_createinfo.levelCount = 1;
     depthtex_createinfo.sampleCount = render_state.sample_count;
     depthtex_createinfo.usageFlags = SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET_BIT;
@@ -283,8 +282,7 @@ CreateMSAATexture(Uint32 drawablew, Uint32 drawableh)
     msaatex_createinfo.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8;
     msaatex_createinfo.width = drawablew;
     msaatex_createinfo.height = drawableh;
-    msaatex_createinfo.depth = 1;
-    msaatex_createinfo.layerCount = 1;
+    msaatex_createinfo.layerCountOrDepth = 1;
     msaatex_createinfo.levelCount = 1;
     msaatex_createinfo.sampleCount = SDL_GPU_SAMPLECOUNT_4;
     msaatex_createinfo.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET_BIT | SDL_GPU_TEXTUREUSAGE_SAMPLER_BIT;


### PR DESCRIPTION
Layer count and depth are mutually exclusive. For 3D textures layer count has to be 1, and for everything else depth has to be 1, so this revision merges them into one field.

Resolves #67 