### PR TITLE
Add BlitRegion struct, add flipMode support

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -431,6 +431,17 @@ typedef struct SDL_GpuTextureRegion
     Uint32 d;
 } SDL_GpuTextureRegion;
 
+typedef struct SDL_GpuBlitRegion
+{
+    SDL_GpuTexture *texture;
+    Uint32 mipLevel;
+    Uint32 layerOrDepthPlane;
+    Uint32 x;
+    Uint32 y;
+    Uint32 w;
+    Uint32 h;
+} SDL_GpuBlitRegion;
+
 typedef struct SDL_GpuBufferLocation
 {
     SDL_GpuBuffer *buffer;
@@ -2022,6 +2033,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuEndCopyPass(
  * \param commandBuffer a command buffer
  * \param source the texture region to copy from
  * \param destination the texture region to copy to
+ * \param flipMode the flip mode for the source texture region
  * \param filterMode the filter mode that will be used when blitting
  * \param cycle if SDL_TRUE, cycles the destination texture if the destination texture is bound, otherwise overwrites the data.
  *
@@ -2030,8 +2042,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuEndCopyPass(
  */
 extern SDL_DECLSPEC void SDLCALL SDL_GpuBlit(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTextureRegion *source,
-    SDL_GpuTextureRegion *destination,
+    SDL_GpuBlitRegion *source,
+    SDL_GpuBlitRegion *destination,
+    SDL_FlipMode flipMode,
     SDL_GpuFilter filterMode,
     SDL_bool cycle);
 

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1153,7 +1153,7 @@ SDL_DYNAPI_PROC(void,SDL_GpuGenerateMipmaps,(SDL_GpuCopyPass *a, SDL_GpuTexture 
 SDL_DYNAPI_PROC(void,SDL_GpuDownloadFromTexture,(SDL_GpuCopyPass *a, SDL_GpuTextureRegion *b, SDL_GpuTextureTransferInfo *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuDownloadFromBuffer,(SDL_GpuCopyPass *a, SDL_GpuBufferRegion *b, SDL_GpuTransferBufferLocation *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuEndCopyPass,(SDL_GpuCopyPass *a),(a),)
-SDL_DYNAPI_PROC(void,SDL_GpuBlit,(SDL_GpuCommandBuffer *a, SDL_GpuTextureRegion *b, SDL_GpuTextureRegion *c, SDL_GpuFilter d, SDL_bool e),(a,b,c,d,e),)
+SDL_DYNAPI_PROC(void,SDL_GpuBlit,(SDL_GpuCommandBuffer *a, SDL_GpuBlitRegion *b, SDL_GpuBlitRegion *c, SDL_FlipMode d, SDL_GpuFilter e, SDL_bool f),(a,b,c,d,e,f),)
 SDL_DYNAPI_PROC(SDL_bool,SDL_GpuSupportsSwapchainComposition,(SDL_GpuDevice *a, SDL_Window *b, SDL_GpuSwapchainComposition c),(a,b,c),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_GpuSupportsPresentMode,(SDL_GpuDevice *a, SDL_Window *b, SDL_GpuPresentMode c),(a,b,c),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_GpuClaimWindow,(SDL_GpuDevice *a, SDL_Window *b, SDL_GpuSwapchainComposition c, SDL_GpuPresentMode d),(a,b,c,d),return)

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -244,8 +244,9 @@ SDL_GpuGraphicsPipeline *SDL_Gpu_FetchBlitPipeline(
 
 void SDL_Gpu_BlitCommon(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTextureRegion *source,
-    SDL_GpuTextureRegion *destination,
+    SDL_GpuBlitRegion *source,
+    SDL_GpuBlitRegion *destination,
+    SDL_FlipMode flipMode,
     SDL_GpuFilter filterMode,
     SDL_bool cycle,
     SDL_GpuSampler *blitLinearSampler,
@@ -574,8 +575,9 @@ struct SDL_GpuDevice
 
     void (*Blit)(
         SDL_GpuCommandBuffer *commandBuffer,
-        SDL_GpuTextureRegion *source,
-        SDL_GpuTextureRegion *destination,
+        SDL_GpuBlitRegion *source,
+        SDL_GpuBlitRegion *destination,
+        SDL_FlipMode flipMode,
         SDL_GpuFilter filterMode,
         SDL_bool cycle);
 

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -4076,8 +4076,9 @@ static void D3D11_PushFragmentUniformData(
 
 static void D3D11_Blit(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTextureRegion *source,
-    SDL_GpuTextureRegion *destination,
+    SDL_GpuBlitRegion *source,
+    SDL_GpuBlitRegion *destination,
+    SDL_FlipMode flipMode,
     SDL_GpuFilter filterMode,
     SDL_bool cycle)
 {
@@ -4089,6 +4090,7 @@ static void D3D11_Blit(
         commandBuffer,
         source,
         destination,
+        flipMode,
         filterMode,
         cycle,
         renderer->blitLinearSampler,

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -5609,8 +5609,9 @@ static void D3D12_GenerateMipmaps(
 
 static void D3D12_Blit(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTextureRegion *source,
-    SDL_GpuTextureRegion *destination,
+    SDL_GpuBlitRegion *source,
+    SDL_GpuBlitRegion *destination,
+    SDL_FlipMode flipMode,
     SDL_GpuFilter filterMode,
     SDL_bool cycle)
 {
@@ -5621,6 +5622,7 @@ static void D3D12_Blit(
         commandBuffer,
         source,
         destination,
+        flipMode,
         filterMode,
         cycle,
         renderer->blitLinearSampler,

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2866,8 +2866,9 @@ static void METAL_PushFragmentUniformData(
 
 static void METAL_Blit(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTextureRegion *source,
-    SDL_GpuTextureRegion *destination,
+    SDL_GpuBlitRegion *source,
+    SDL_GpuBlitRegion *destination,
+    SDL_FlipMode flipMode,
     SDL_GpuFilter filterMode,
     SDL_bool cycle)
 {
@@ -2878,6 +2879,7 @@ static void METAL_Blit(
         commandBuffer,
         source,
         destination,
+        flipMode,
         filterMode,
         cycle,
         renderer->blitLinearSampler,

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9204,25 +9204,33 @@ static void VULKAN_EndCopyPass(
 
 static void VULKAN_Blit(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTextureRegion *source,
-    SDL_GpuTextureRegion *destination,
+    SDL_GpuBlitRegion *source,
+    SDL_GpuBlitRegion *destination,
+    SDL_FlipMode flipMode,
     SDL_GpuFilter filterMode,
     SDL_bool cycle)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    TextureCommonHeader *srcHeader = (TextureCommonHeader *)source->texture;
+    TextureCommonHeader *dstHeader = (TextureCommonHeader *)destination->texture;
     VkImageBlit region;
+    Uint32 srcLayer = srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : source->layerOrDepthPlane;
+    Uint32 srcDepth = srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? source->layerOrDepthPlane : 0;
+    Uint32 dstLayer = dstHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : destination->layerOrDepthPlane;
+    Uint32 dstDepth = dstHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? destination->layerOrDepthPlane : 0;
+    int32_t swap;
 
     VulkanTextureSubresource *srcSubresource = VULKAN_INTERNAL_FetchTextureSubresource(
         (VulkanTextureContainer *)source->texture,
-        source->layer,
+        srcLayer,
         source->mipLevel);
 
     VulkanTextureSubresource *dstSubresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
         renderer,
         vulkanCommandBuffer,
         (VulkanTextureContainer *)destination->texture,
-        destination->layer,
+        dstLayer,
         destination->mipLevel,
         cycle,
         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION);
@@ -9239,10 +9247,24 @@ static void VULKAN_Blit(
     region.srcSubresource.mipLevel = srcSubresource->level;
     region.srcOffsets[0].x = source->x;
     region.srcOffsets[0].y = source->y;
-    region.srcOffsets[0].z = source->z;
+    region.srcOffsets[0].z = srcDepth;
     region.srcOffsets[1].x = source->x + source->w;
     region.srcOffsets[1].y = source->y + source->h;
-    region.srcOffsets[1].z = source->z + source->d;
+    region.srcOffsets[1].z = srcDepth + 1;
+
+    if (flipMode & SDL_FLIP_HORIZONTAL) {
+        /* flip the x positions */
+        swap = region.srcOffsets[0].x;
+        region.srcOffsets[0].x = region.srcOffsets[1].x;
+        region.srcOffsets[1].x = swap;
+    }
+
+    if (flipMode & SDL_FLIP_VERTICAL) {
+        /* flip the y positions */
+        swap = region.srcOffsets[0].y;
+        region.srcOffsets[0].y = region.srcOffsets[1].y;
+        region.srcOffsets[1].y = swap;
+    }
 
     region.dstSubresource.aspectMask = dstSubresource->parent->aspectFlags;
     region.dstSubresource.baseArrayLayer = dstSubresource->layer;
@@ -9250,10 +9272,10 @@ static void VULKAN_Blit(
     region.dstSubresource.mipLevel = dstSubresource->level;
     region.dstOffsets[0].x = destination->x;
     region.dstOffsets[0].y = destination->y;
-    region.dstOffsets[0].z = destination->z;
+    region.dstOffsets[0].z = dstDepth;
     region.dstOffsets[1].x = destination->x + destination->w;
     region.dstOffsets[1].y = destination->y + destination->h;
-    region.dstOffsets[1].z = destination->z + destination->d;
+    region.dstOffsets[1].z = dstDepth + 1;
 
     renderer->vkCmdBlitImage(
         vulkanCommandBuffer->commandBuffer,

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -306,8 +306,8 @@ Render(SDL_Window *window, const int windownum)
     SDL_GpuCommandBuffer *cmd;
     SDL_GpuRenderPass *pass;
     SDL_GpuBufferBinding vertex_binding;
-    SDL_GpuTextureRegion src_region;
-    SDL_GpuTextureRegion dst_region;
+    SDL_GpuBlitRegion src_region;
+    SDL_GpuBlitRegion dst_region;
 
     /* Acquire the swapchain texture */
 
@@ -397,12 +397,11 @@ Render(SDL_Window *window, const int windownum)
         src_region.texture = winstate->tex_msaa;
         src_region.w = drawablew;
         src_region.h = drawableh;
-        src_region.d = 1;
 
         dst_region = src_region;
         dst_region.texture = swapchain;
 
-        SDL_GpuBlit(cmd, &src_region, &dst_region, SDL_GPU_FILTER_LINEAR, SDL_FALSE);
+        SDL_GpuBlit(cmd, &src_region, &dst_region, SDL_FLIP_NONE, SDL_GPU_FILTER_LINEAR, SDL_FALSE);
     }
 
     /* Submit the command buffer! */


### PR DESCRIPTION
Resolves https://github.com/thatcosmonaut/SDL/issues/206. Reusing SDL_render's `SDL_FlipMode` enum here to avoid reinventing the wheel.