### PR TITLE
GenerateMipmaps

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2015,18 +2015,6 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuCopyBufferToBuffer(
     SDL_bool cycle);
 
 /**
- * Generates mipmaps for the given texture.
- *
- * \param copyPass a copy pass handle
- * \param texture a texture with more than 1 mip level
- *
- * \since This function is available since SDL 3.x.x
- */
-extern SDL_DECLSPEC void SDLCALL SDL_GpuGenerateMipmaps(
-    SDL_GpuCopyPass *copyPass,
-    SDL_GpuTexture *texture);
-
-/**
  * Copies data from a texture to a transfer buffer on the GPU timeline.
  * This data is not guaranteed to be copied until the command buffer fence is signaled.
  *
@@ -2067,8 +2055,21 @@ extern SDL_DECLSPEC void SDLCALL SDL_GpuEndCopyPass(
     SDL_GpuCopyPass *copyPass);
 
 /**
+ * Generates mipmaps for the given texture.
+ * This function must not be called inside of any pass.
+ *
+ * \param commandBuffer a commandBuffer
+ * \param texture a texture with more than 1 mip level
+ *
+ * \since This function is available since SDL 3.x.x
+ */
+extern SDL_DECLSPEC void SDLCALL SDL_GpuGenerateMipmaps(
+    SDL_GpuCommandBuffer *commandBuffer,
+    SDL_GpuTexture *texture);
+
+/**
  * Blits from a source texture region to a destination texture region.
- * This function must not be called inside of any render, compute, or copy pass.
+ * This function must not be called inside of any pass.
  *
  * \param commandBuffer a command buffer
  * \param source the texture region to copy from

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1149,7 +1149,7 @@ SDL_DYNAPI_PROC(void,SDL_GpuUploadToTexture,(SDL_GpuCopyPass *a, SDL_GpuTextureT
 SDL_DYNAPI_PROC(void,SDL_GpuUploadToBuffer,(SDL_GpuCopyPass *a, SDL_GpuTransferBufferLocation *b, SDL_GpuBufferRegion *c, SDL_bool d),(a,b,c,d),)
 SDL_DYNAPI_PROC(void,SDL_GpuCopyTextureToTexture,(SDL_GpuCopyPass *a, SDL_GpuTextureLocation *b, SDL_GpuTextureLocation *c, Uint32 d, Uint32 e, Uint32 f, SDL_bool g),(a,b,c,d,e,f,g),)
 SDL_DYNAPI_PROC(void,SDL_GpuCopyBufferToBuffer,(SDL_GpuCopyPass *a, SDL_GpuBufferLocation *b, SDL_GpuBufferLocation *c, Uint32 d, SDL_bool e),(a,b,c,d,e),)
-SDL_DYNAPI_PROC(void,SDL_GpuGenerateMipmaps,(SDL_GpuCopyPass *a, SDL_GpuTexture *b),(a,b),)
+SDL_DYNAPI_PROC(void,SDL_GpuGenerateMipmaps,(SDL_GpuCommandBuffer *a, SDL_GpuTexture *b),(a,b),)
 SDL_DYNAPI_PROC(void,SDL_GpuDownloadFromTexture,(SDL_GpuCopyPass *a, SDL_GpuTextureRegion *b, SDL_GpuTextureTransferInfo *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuDownloadFromBuffer,(SDL_GpuCopyPass *a, SDL_GpuBufferRegion *b, SDL_GpuTransferBufferLocation *c),(a,b,c),)
 SDL_DYNAPI_PROC(void,SDL_GpuEndCopyPass,(SDL_GpuCopyPass *a),(a),)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -303,8 +303,8 @@ void SDL_Gpu_BlitCommon(
         &textureSamplerBinding,
         1);
 
-    blitFragmentUniforms.left = (float)source->x / srcHeader->info.width;
-    blitFragmentUniforms.top = (float)source->y / srcHeader->info.height;
+    blitFragmentUniforms.left = (float)source->x / (srcHeader->info.width >> source->mipLevel);
+    blitFragmentUniforms.top = (float)source->y / (srcHeader->info.height >> source->mipLevel);
     blitFragmentUniforms.width = (float)source->w / (srcHeader->info.width >> source->mipLevel);
     blitFragmentUniforms.height = (float)source->h / (srcHeader->info.height >> source->mipLevel);
     blitFragmentUniforms.mipLevel = source->mipLevel;

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1927,6 +1927,12 @@ void SDL_GpuGenerateMipmaps(
         return;
     }
 
+    TextureCommonHeader *header = (TextureCommonHeader *)texture;
+    if (header->info.levelCount <= 1) {
+        SDL_LogError(SDL_LOG_CATEGORY_GPU, "Cannot generate mipmaps for texture with levelCount <= 1!");
+        return;
+    }
+
     COPYPASS_DEVICE->GenerateMipmaps(
         COPYPASS_COMMAND_BUFFER,
         texture);

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
   Simple DirectMedia Layer
   Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
 
@@ -305,8 +305,8 @@ void SDL_Gpu_BlitCommon(
 
     blitFragmentUniforms.left = (float)source->x / srcHeader->info.width;
     blitFragmentUniforms.top = (float)source->y / srcHeader->info.height;
-    blitFragmentUniforms.width = (float)source->w / srcHeader->info.width;
-    blitFragmentUniforms.height = (float)source->h / srcHeader->info.height;
+    blitFragmentUniforms.width = (float)source->w / (srcHeader->info.width >> source->mipLevel);
+    blitFragmentUniforms.height = (float)source->h / (srcHeader->info.height >> source->mipLevel);
     blitFragmentUniforms.mipLevel = source->mipLevel;
 
     layerDivisor = (srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D) ? srcHeader->info.layerCountOrDepth : 1;

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -46,6 +46,15 @@
         ((CommandBufferCommonHeader *)commandBuffer)->computePass.inProgress || \
         ((CommandBufferCommonHeader *)commandBuffer)->copyPass.inProgress) {    \
         SDL_assert_release(!"Pass already in progress!");                       \
+        return;                                                            \
+    }
+
+#define CHECK_ANY_PASS_IN_PROGRESS_RETURN_NULL                                              \
+    if (                                                                        \
+        ((CommandBufferCommonHeader *)commandBuffer)->renderPass.inProgress ||  \
+        ((CommandBufferCommonHeader *)commandBuffer)->computePass.inProgress || \
+        ((CommandBufferCommonHeader *)commandBuffer)->copyPass.inProgress) {    \
+        SDL_assert_release(!"Pass already in progress!");                       \
         return NULL;                                                            \
     }
 
@@ -1133,7 +1142,7 @@ SDL_GpuRenderPass *SDL_GpuBeginRenderPass(
 
     if (COMMAND_BUFFER_DEVICE->debugMode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
-        CHECK_ANY_PASS_IN_PROGRESS
+        CHECK_ANY_PASS_IN_PROGRESS_RETURN_NULL
     }
 
     COMMAND_BUFFER_DEVICE->BeginRenderPass(
@@ -1579,7 +1588,7 @@ SDL_GpuComputePass *SDL_GpuBeginComputePass(
     }
     if (COMMAND_BUFFER_DEVICE->debugMode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
-        CHECK_ANY_PASS_IN_PROGRESS
+        CHECK_ANY_PASS_IN_PROGRESS_RETURN_NULL
     }
 
     COMMAND_BUFFER_DEVICE->BeginComputePass(
@@ -1787,7 +1796,7 @@ SDL_GpuCopyPass *SDL_GpuBeginCopyPass(
 
     if (COMMAND_BUFFER_DEVICE->debugMode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
-        CHECK_ANY_PASS_IN_PROGRESS
+        CHECK_ANY_PASS_IN_PROGRESS_RETURN_NULL
     }
 
     COMMAND_BUFFER_DEVICE->BeginCopyPass(
@@ -1914,37 +1923,6 @@ void SDL_GpuCopyBufferToBuffer(
         cycle);
 }
 
-void SDL_GpuGenerateMipmaps(
-    SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTexture *texture)
-{
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
-        return;
-    }
-    if (texture == NULL) {
-        SDL_InvalidParamError("texture");
-        return;
-    }
-
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
-        TextureCommonHeader *header = (TextureCommonHeader *)texture;
-        if (header->info.levelCount <= 1) {
-            SDL_assert_release(!"Cannot generate mipmaps for texture with levelCount <= 1!");
-            return;
-        }
-
-        if (!(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER_BIT) || !(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET_BIT)) {
-            SDL_assert_release(!"GenerateMipmaps texture must be created with SAMPLER_BIT and COLOR_TARGET_BIT usage flags!");
-            return;
-        }
-    }
-
-    COMMAND_BUFFER_DEVICE->GenerateMipmaps(
-        commandBuffer,
-        texture);
-}
-
 void SDL_GpuDownloadFromTexture(
     SDL_GpuCopyPass *copyPass,
     SDL_GpuTextureRegion *source,
@@ -2011,6 +1989,40 @@ void SDL_GpuEndCopyPass(
     ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->copyPass.inProgress = SDL_FALSE;
 }
 
+void SDL_GpuGenerateMipmaps(
+    SDL_GpuCommandBuffer *commandBuffer,
+    SDL_GpuTexture *texture)
+{
+    if (commandBuffer == NULL) {
+        SDL_InvalidParamError("commandBuffer");
+        return;
+    }
+    if (texture == NULL) {
+        SDL_InvalidParamError("texture");
+        return;
+    }
+
+    if (COMMAND_BUFFER_DEVICE->debugMode) {
+        CHECK_COMMAND_BUFFER
+        CHECK_ANY_PASS_IN_PROGRESS
+
+        TextureCommonHeader *header = (TextureCommonHeader *)texture;
+        if (header->info.levelCount <= 1) {
+            SDL_assert_release(!"Cannot generate mipmaps for texture with levelCount <= 1!");
+            return;
+        }
+
+        if (!(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER_BIT) || !(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET_BIT)) {
+            SDL_assert_release(!"GenerateMipmaps texture must be created with SAMPLER_BIT and COLOR_TARGET_BIT usage flags!");
+            return;
+        }
+    }
+
+    COMMAND_BUFFER_DEVICE->GenerateMipmaps(
+        commandBuffer,
+        texture);
+}
+
 void SDL_GpuBlit(
     SDL_GpuCommandBuffer *commandBuffer,
     SDL_GpuBlitRegion *source,
@@ -2034,6 +2046,7 @@ void SDL_GpuBlit(
 
     if (COMMAND_BUFFER_DEVICE->debugMode) {
         CHECK_COMMAND_BUFFER
+        CHECK_ANY_PASS_IN_PROGRESS
 
         /* Validation */
         SDL_bool failed = SDL_FALSE;

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1927,10 +1927,17 @@ void SDL_GpuGenerateMipmaps(
         return;
     }
 
-    TextureCommonHeader *header = (TextureCommonHeader *)texture;
-    if (header->info.levelCount <= 1) {
-        SDL_LogError(SDL_LOG_CATEGORY_GPU, "Cannot generate mipmaps for texture with levelCount <= 1!");
-        return;
+    if (COMMAND_BUFFER_DEVICE->debugMode) {
+        TextureCommonHeader *header = (TextureCommonHeader *)texture;
+        if (header->info.levelCount <= 1) {
+            SDL_assert_release(!"Cannot generate mipmaps for texture with levelCount <= 1!");
+            return;
+        }
+
+        if (!(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER_BIT) || !(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET_BIT)) {
+            SDL_assert_release(!"GenerateMipmaps texture must be created with SAMPLER_BIT and COLOR_TARGET_BIT usage flags!");
+            return;
+        }
     }
 
     COMMAND_BUFFER_DEVICE->GenerateMipmaps(

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
   Simple DirectMedia Layer
   Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
 
@@ -1915,11 +1915,11 @@ void SDL_GpuCopyBufferToBuffer(
 }
 
 void SDL_GpuGenerateMipmaps(
-    SDL_GpuCopyPass *copyPass,
+    SDL_GpuCommandBuffer *commandBuffer,
     SDL_GpuTexture *texture)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (commandBuffer == NULL) {
+        SDL_InvalidParamError("commandBuffer");
         return;
     }
     if (texture == NULL) {
@@ -1933,8 +1933,8 @@ void SDL_GpuGenerateMipmaps(
         return;
     }
 
-    COPYPASS_DEVICE->GenerateMipmaps(
-        COPYPASS_COMMAND_BUFFER,
+    COMMAND_BUFFER_DEVICE->GenerateMipmaps(
+        commandBuffer,
         texture);
 }
 

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -5658,24 +5658,21 @@ static void D3D12_GenerateMipmaps(
 
             SDL_GpuBlit(
                 commandBuffer,
-                &(SDL_GpuTextureRegion){
+                &(SDL_GpuBlitRegion){
                     .texture = texture,
-                    .layer = layer,
+                    .layerOrDepthPlane = layerOrDepthIndex,
                     .mipLevel = levelIndex - 1,
-                    .z = depthSlice,
                     .w = container->header.info.width >> (levelIndex - 1),
                     .h = container->header.info.height >> (levelIndex - 1),
-                    .d = 1,
                 },
-                &(SDL_GpuTextureRegion){
+                &(SDL_GpuBlitRegion){
                     .texture = texture,
-                    .layer = layer,
+                    .layerOrDepthPlane = layerOrDepthIndex,
                     .mipLevel = levelIndex,
-                    .z = depthSlice,
                     .w = container->header.info.width >> levelIndex,
                     .h = container->header.info.height >> levelIndex,
-                    .d = 1
                 },
+                SDL_FLIP_NONE,
                 SDL_GPU_FILTER_LINEAR,
                 SDL_FALSE);
         }

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -5653,9 +5653,6 @@ static void D3D12_GenerateMipmaps(
     /* We have to do this one subresource at a time */
     for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < container->header.info.layerCountOrDepth; layerOrDepthIndex += 1) {
         for (Uint32 levelIndex = 1; levelIndex < container->header.info.levelCount; levelIndex += 1) {
-            Uint32 layer = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : layerOrDepthIndex;
-            Uint32 depthSlice = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? layerOrDepthIndex : 0;
-
             SDL_GpuBlit(
                 commandBuffer,
                 &(SDL_GpuBlitRegion){

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -5662,6 +5662,7 @@ static void D3D12_GenerateMipmaps(
                     .texture = texture,
                     .layer = layer,
                     .mipLevel = levelIndex - 1,
+                    .z = depthSlice,
                     .w = container->header.info.width >> (levelIndex - 1),
                     .h = container->header.info.height >> (levelIndex - 1),
                     .d = 1,
@@ -5670,6 +5671,7 @@ static void D3D12_GenerateMipmaps(
                     .texture = texture,
                     .layer = layer,
                     .mipLevel = levelIndex,
+                    .z = depthSlice,
                     .w = container->header.info.width >> levelIndex,
                     .h = container->header.info.height >> levelIndex,
                     .d = 1

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3911,9 +3911,6 @@ static void D3D12_INTERNAL_TrackUniformBuffer(
         commandBuffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_realloc(
             commandBuffer->usedUniformBuffers,
             commandBuffer->usedUniformBufferCapacity * sizeof(D3D12UniformBuffer *));
-        for (i = commandBuffer->usedUniformBufferCount; i < commandBuffer->usedUniformBufferCapacity; i += 1) {
-            SDL_zerop(commandBuffer->usedUniformBuffers[i]);
-        }
     }
 
     commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
@@ -5628,7 +5625,177 @@ static void D3D12_EndCopyPass(
 
 static void D3D12_GenerateMipmaps(
     SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTexture *texture) { SDL_assert(SDL_FALSE); }
+    SDL_GpuTexture *texture)
+{
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
+    D3D12TextureContainer *container = (D3D12TextureContainer *)texture;
+    SDL_GpuGraphicsPipeline *blitPipeline;
+
+    blitPipeline = SDL_Gpu_FetchBlitPipeline(
+        renderer->sdlGpuDevice,
+        container->header.info.type,
+        container->header.info.format,
+        renderer->blitVertexShader,
+        renderer->blitFrom2DShader,
+        renderer->blitFrom2DArrayShader,
+        renderer->blitFrom3DShader,
+        renderer->blitFromCubeShader,
+        &renderer->blitPipelines,
+        &renderer->blitPipelineCount,
+        &renderer->blitPipelineCapacity);
+
+    if (blitPipeline == NULL) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not fetch blit pipeline");
+        return;
+    }
+
+    /* We have to do this the hard way, one subresource at a time */
+    for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < container->header.info.layerCountOrDepth; layerOrDepthIndex += 1) {
+        for (Uint32 levelIndex = 1; levelIndex < container->header.info.levelCount; levelIndex += 1) {
+            Uint32 layer = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : layerOrDepthIndex;
+            Uint32 depthSlice = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? layerOrDepthIndex : 0;
+
+            D3D12TextureSubresource *srcSubresource = D3D12_INTERNAL_FetchTextureSubresource(
+                container,
+                layer,
+                levelIndex - 1);
+            D3D12TextureSubresource *dstSubresource = D3D12_INTERNAL_FetchTextureSubresource(
+                container,
+                layer,
+                levelIndex);
+
+            /* destination barrier */
+            D3D12_RESOURCE_BARRIER barrierDesc;
+            barrierDesc.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+            barrierDesc.Flags = 0;
+            barrierDesc.Transition.StateBefore = D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE;
+            barrierDesc.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+            barrierDesc.Transition.pResource = dstSubresource->parent->resource;
+            barrierDesc.Transition.Subresource = dstSubresource->index;
+            ID3D12GraphicsCommandList_ResourceBarrier(
+                d3d12CommandBuffer->graphicsCommandList,
+                1,
+                &barrierDesc);
+
+            D3D12_CPU_DESCRIPTOR_HANDLE rtv = dstSubresource->rtvHandles[depthSlice].cpuHandle;
+
+            ID3D12GraphicsCommandList_OMSetRenderTargets(
+                d3d12CommandBuffer->graphicsCommandList,
+                1,
+                &rtv,
+                SDL_FALSE,
+                NULL);
+
+            Uint32 w = container->header.info.width >> dstSubresource->level;
+            Uint32 h = container->header.info.height >> dstSubresource->level;
+
+            D3D12_VIEWPORT d3d12Viewport;
+            d3d12Viewport.TopLeftX = 0;
+            d3d12Viewport.TopLeftY = 0;
+            d3d12Viewport.Width = (float)w;
+            d3d12Viewport.Height = (float)h;
+            d3d12Viewport.MinDepth = 0.0f;
+            d3d12Viewport.MaxDepth = 1.0f;
+            ID3D12GraphicsCommandList_RSSetViewports(d3d12CommandBuffer->graphicsCommandList, 1, &d3d12Viewport);
+
+            D3D12_RECT scissorRect;
+            scissorRect.left = 0;
+            scissorRect.top = 0;
+            scissorRect.right = w;
+            scissorRect.bottom = h;
+            ID3D12GraphicsCommandList_RSSetScissorRects(d3d12CommandBuffer->graphicsCommandList, 1, &scissorRect);
+
+            D3D12GraphicsPipeline *pipeline = (D3D12GraphicsPipeline *)blitPipeline;
+
+            ID3D12GraphicsCommandList_SetPipelineState(d3d12CommandBuffer->graphicsCommandList, pipeline->pipelineState);
+            ID3D12GraphicsCommandList_SetGraphicsRootSignature(d3d12CommandBuffer->graphicsCommandList, pipeline->rootSignature->handle);
+            ID3D12GraphicsCommandList_IASetPrimitiveTopology(d3d12CommandBuffer->graphicsCommandList, SDLToD3D12_PrimitiveType[pipeline->primitiveType]);
+
+            float blendFactor[4] = {
+                pipeline->blendConstants[0],
+                pipeline->blendConstants[1],
+                pipeline->blendConstants[2],
+                pipeline->blendConstants[3]
+            };
+            ID3D12GraphicsCommandList_OMSetBlendFactor(d3d12CommandBuffer->graphicsCommandList, blendFactor);
+            ID3D12GraphicsCommandList_OMSetStencilRef(d3d12CommandBuffer->graphicsCommandList, pipeline->stencilRef);
+
+            BlitFragmentUniforms blitFragmentUniforms;
+            blitFragmentUniforms.left = 0;
+            blitFragmentUniforms.top = 0;
+            blitFragmentUniforms.width = 1.0f;
+            blitFragmentUniforms.height = 1.0f;
+            blitFragmentUniforms.mipLevel = levelIndex - 1;
+            blitFragmentUniforms.layerOrDepth = (container->header.info.type == SDL_GPU_TEXTURETYPE_3D) ? (layerOrDepthIndex / (float)container->header.info.layerCountOrDepth) : layer;
+
+            D3D12_INTERNAL_PushUniformData(
+                d3d12CommandBuffer,
+                SDL_GPU_SHADERSTAGE_FRAGMENT,
+                0,
+                &blitFragmentUniforms,
+                sizeof(BlitFragmentUniforms));
+
+            D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
+
+            D3D12_INTERNAL_WriteGPUDescriptors(
+                d3d12CommandBuffer,
+                D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
+                &((D3D12Sampler *)renderer->blitLinearSampler)->handle.cpuHandle,
+                1,
+                &gpuDescriptorHandle);
+
+            ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
+                d3d12CommandBuffer->graphicsCommandList,
+                pipeline->rootSignature->fragmentSamplerRootIndex,
+                gpuDescriptorHandle);
+
+            D3D12_INTERNAL_WriteGPUDescriptors(
+                d3d12CommandBuffer,
+                D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
+                &srcSubresource->parent->srvHandle.cpuHandle,
+                1,
+                &gpuDescriptorHandle);
+
+            ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
+                d3d12CommandBuffer->graphicsCommandList,
+                pipeline->rootSignature->fragmentSamplerTextureRootIndex,
+                gpuDescriptorHandle);
+
+            ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView(
+                d3d12CommandBuffer->graphicsCommandList,
+                pipeline->rootSignature->fragmentUniformBufferRootIndex[0],
+                d3d12CommandBuffer->fragmentUniformBuffers[0]->buffer->virtualAddress + d3d12CommandBuffer->fragmentUniformBuffers[0]->drawOffset);
+
+            ID3D12GraphicsCommandList_DrawInstanced(
+                d3d12CommandBuffer->graphicsCommandList,
+                3,
+                1,
+                0,
+                0);
+
+            /* End render pass */
+            ID3D12GraphicsCommandList_OMSetRenderTargets(
+                d3d12CommandBuffer->graphicsCommandList,
+                0,
+                NULL,
+                SDL_FALSE,
+                NULL);
+
+            barrierDesc.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+            barrierDesc.Transition.StateAfter = D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE;
+            barrierDesc.Transition.pResource = dstSubresource->parent->resource;
+            barrierDesc.Transition.Subresource = dstSubresource->index;
+
+            ID3D12GraphicsCommandList_ResourceBarrier(
+                d3d12CommandBuffer->graphicsCommandList,
+                1,
+                &barrierDesc);
+        }
+    }
+
+    D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, container->activeTexture);
+}
 
 static void D3D12_Blit(
     SDL_GpuCommandBuffer *commandBuffer,

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1803,11 +1803,6 @@ static void METAL_GenerateMipmaps(
         MetalTextureContainer *container = (MetalTextureContainer *)texture;
         MetalTexture *metalTexture = container->activeTexture;
 
-        if (container->header.info.levelCount <= 1) {
-            SDL_LogError(SDL_LOG_CATEGORY_GPU, "Cannot generate mipmaps for texture with levelCount <= 1!");
-            return;
-        }
-
         [metalCommandBuffer->blitEncoder
             generateMipmapsForTexture:metalTexture->handle];
 

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1794,22 +1794,6 @@ static void METAL_CopyBufferToBuffer(
     }
 }
 
-static void METAL_GenerateMipmaps(
-    SDL_GpuCommandBuffer *commandBuffer,
-    SDL_GpuTexture *texture)
-{
-    @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
-        MetalTextureContainer *container = (MetalTextureContainer *)texture;
-        MetalTexture *metalTexture = container->activeTexture;
-
-        [metalCommandBuffer->blitEncoder
-            generateMipmapsForTexture:metalTexture->handle];
-
-        METAL_INTERNAL_TrackTexture(metalCommandBuffer, metalTexture);
-    }
-}
-
 static void METAL_DownloadFromTexture(
     SDL_GpuCommandBuffer *commandBuffer,
     SDL_GpuTextureRegion *source,
@@ -1888,6 +1872,24 @@ static void METAL_EndCopyPass(
         MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         [metalCommandBuffer->blitEncoder endEncoding];
         metalCommandBuffer->blitEncoder = nil;
+    }
+}
+
+static void METAL_GenerateMipmaps(
+    SDL_GpuCommandBuffer *commandBuffer,
+    SDL_GpuTexture *texture)
+{
+    @autoreleasepool {
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+        MetalTextureContainer *container = (MetalTextureContainer *)texture;
+        MetalTexture *metalTexture = container->activeTexture;
+
+        METAL_BeginCopyPass(commandBuffer);
+        [metalCommandBuffer->blitEncoder
+            generateMipmapsForTexture:metalTexture->handle];
+        METAL_EndCopyPass(commandBuffer);
+
+        METAL_INTERNAL_TrackTexture(metalCommandBuffer, metalTexture);
     }
 }
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9135,11 +9135,11 @@ static void VULKAN_GenerateMipmaps(
 
             Uint32 srcSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level - 1,
-                layerOrDepthIndex,
+                layer,
                 vulkanTexture->levelCount);
             Uint32 dstSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level,
-                layerOrDepthIndex,
+                layer,
                 vulkanTexture->levelCount);
 
             srcTextureSubresource = &vulkanTexture->subresources[srcSubresourceIndex];

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9126,18 +9126,20 @@ static void VULKAN_GenerateMipmaps(
     VulkanTextureSubresource *srcTextureSubresource;
     VulkanTextureSubresource *dstTextureSubresource;
     VkImageBlit blit;
-    Uint32 layer, level;
 
     /* Blit each slice sequentially. Barriers, barriers everywhere! */
-    for (layer = 0; layer < vulkanTexture->layerCount; layer += 1)
-        for (level = 1; level < vulkanTexture->levelCount; level += 1) {
+    for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < vulkanTexture->layerCount; layerOrDepthIndex += 1)
+        for (Uint32 level = 1; level < vulkanTexture->levelCount; level += 1) {
+            Uint32 layer = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? 0 : layerOrDepthIndex;
+            Uint32 depth = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? layerOrDepthIndex : 0;
+
             Uint32 srcSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level - 1,
-                layer,
+                layerOrDepthIndex,
                 vulkanTexture->levelCount);
             Uint32 dstSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level,
-                layer,
+                layerOrDepthIndex,
                 vulkanTexture->levelCount);
 
             srcTextureSubresource = &vulkanTexture->subresources[srcSubresourceIndex];
@@ -9157,27 +9159,27 @@ static void VULKAN_GenerateMipmaps(
 
             blit.srcOffsets[0].x = 0;
             blit.srcOffsets[0].y = 0;
-            blit.srcOffsets[0].z = 0;
+            blit.srcOffsets[0].z = depth;
 
             blit.srcOffsets[1].x = vulkanTexture->dimensions.width >> (level - 1);
             blit.srcOffsets[1].y = vulkanTexture->dimensions.height >> (level - 1);
-            blit.srcOffsets[1].z = 1;
+            blit.srcOffsets[1].z = depth + 1;
 
             blit.dstOffsets[0].x = 0;
             blit.dstOffsets[0].y = 0;
-            blit.dstOffsets[0].z = 0;
+            blit.dstOffsets[0].z = depth;
 
             blit.dstOffsets[1].x = vulkanTexture->dimensions.width >> level;
             blit.dstOffsets[1].y = vulkanTexture->dimensions.height >> level;
-            blit.dstOffsets[1].z = 1;
+            blit.dstOffsets[1].z = depth + 1;
 
             blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            blit.srcSubresource.baseArrayLayer = layer;
+            blit.srcSubresource.baseArrayLayer = layerOrDepthIndex;
             blit.srcSubresource.layerCount = 1;
             blit.srcSubresource.mipLevel = level - 1;
 
             blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            blit.dstSubresource.baseArrayLayer = layer;
+            blit.dstSubresource.baseArrayLayer = layerOrDepthIndex;
             blit.dstSubresource.layerCount = 1;
             blit.dstSubresource.mipLevel = level;
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9128,10 +9128,6 @@ static void VULKAN_GenerateMipmaps(
     VkImageBlit blit;
     Uint32 layer, level;
 
-    if (vulkanTexture->levelCount <= 1) {
-        return;
-    }
-
     /* Blit each slice sequentially. Barriers, barriers everywhere! */
     for (layer = 0; layer < vulkanTexture->layerCount; layer += 1)
         for (level = 1; level < vulkanTexture->levelCount; level += 1) {

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9174,12 +9174,12 @@ static void VULKAN_GenerateMipmaps(
             blit.dstOffsets[1].z = depth + 1;
 
             blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            blit.srcSubresource.baseArrayLayer = layerOrDepthIndex;
+            blit.srcSubresource.baseArrayLayer = layer;
             blit.srcSubresource.layerCount = 1;
             blit.srcSubresource.mipLevel = level - 1;
 
             blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            blit.dstSubresource.baseArrayLayer = layerOrDepthIndex;
+            blit.dstSubresource.baseArrayLayer = layer;
             blit.dstSubresource.layerCount = 1;
             blit.dstSubresource.mipLevel = level;
 


### PR DESCRIPTION
- Moved GenerateMipmaps out of the copy pass to the command buffer, like Blit. D3D12 needs to blit in the implementation and Metal needs it to be in a copy pass, so it just shouldn't be inside a pass.
- Implemented D3D12 GenerateMipmaps
- Fixed D3D11 GenerateMipmaps
- Fixed Vulkan GenerateMipmaps not taking depth into account
- Fixed BlitCommon not taking mip level into account in the source dimension calculation
- Moved mip level validation on GenerateMipmaps into SDL_gpu.c 

This will probably conflict with #207 because it depends on Blit, so let's merge that one first and go from there.
