### PR TITLE
SDL_GpuSupportsSampleCount

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2363,20 +2363,19 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GpuSupportsTextureFormat(
     SDL_GpuTextureUsageFlags usage);
 
 /**
- * Determines the "best" sample count for a texture format, i.e.
- * the highest supported sample count that is <= the desired sample count.
+ * Determines if a sample count for a texture format is supported.
  *
  * \param device a GPU context
  * \param format the texture format to check
- * \param desiredSampleCount the sample count you want
+ * \param sampleCount the sample count to check
  * \returns a hardware-specific version of min(preferred, possible)
  *
  * \since This function is available since SDL 3.x.x
  */
-extern SDL_DECLSPEC SDL_GpuSampleCount SDLCALL SDL_GpuGetBestSampleCount(
+extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GpuSupportsSampleCount(
     SDL_GpuDevice *device,
     SDL_GpuTextureFormat format,
-    SDL_GpuSampleCount desiredSampleCount);
+    SDL_GpuSampleCount sampleCount);
 
 #ifdef __cplusplus
 }

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -987,7 +987,7 @@ SDL3_0.0.0 {
     SDL_powf;
     SDL_qsort;
     SDL_qsort_r;
-    SDL_rand;  
+    SDL_rand;
     SDL_rand_bits;
     SDL_rand_bits_r;
     SDL_rand_r;
@@ -1138,7 +1138,7 @@ SDL3_0.0.0 {
     SDL_GpuReleaseFence;
     SDL_GpuTextureFormatTexelBlockSize;
     SDL_GpuSupportsTextureFormat;
-    SDL_GpuGetBestSampleCount;
+    SDL_GpuSupportsSampleCount;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -1163,4 +1163,4 @@
 #define SDL_GpuReleaseFence SDL_GpuReleaseFence_REAL
 #define SDL_GpuTextureFormatTexelBlockSize SDL_GpuTextureFormatTexelBlockSize_REAL
 #define SDL_GpuSupportsTextureFormat SDL_GpuSupportsTextureFormat_REAL
-#define SDL_GpuGetBestSampleCount SDL_GpuGetBestSampleCount_REAL
+#define SDL_GpuSupportsSampleCount SDL_GpuSupportsSampleCount_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1169,4 +1169,4 @@ SDL_DYNAPI_PROC(SDL_bool,SDL_GpuQueryFence,(SDL_GpuDevice *a, SDL_GpuFence *b),(
 SDL_DYNAPI_PROC(void,SDL_GpuReleaseFence,(SDL_GpuDevice *a, SDL_GpuFence *b),(a,b),)
 SDL_DYNAPI_PROC(Uint32,SDL_GpuTextureFormatTexelBlockSize,(SDL_GpuTextureFormat a),(a),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_GpuSupportsTextureFormat,(SDL_GpuDevice *a, SDL_GpuTextureFormat b, SDL_GpuTextureType c, SDL_GpuTextureUsageFlags d),(a,b,c,d),return)
-SDL_DYNAPI_PROC(SDL_GpuSampleCount,SDL_GpuGetBestSampleCount,(SDL_GpuDevice *a, SDL_GpuTextureFormat b, SDL_GpuSampleCount c),(a,b,c),return)
+SDL_DYNAPI_PROC(SDL_bool,SDL_GpuSupportsSampleCount,(SDL_GpuDevice *a, SDL_GpuTextureFormat b, SDL_GpuSampleCount c),(a,b,c),return)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -576,10 +576,10 @@ SDL_bool SDL_GpuSupportsTextureFormat(
         usage);
 }
 
-SDL_GpuSampleCount SDL_GpuGetBestSampleCount(
+SDL_bool SDL_GpuSupportsSampleCount(
     SDL_GpuDevice *device,
     SDL_GpuTextureFormat format,
-    SDL_GpuSampleCount desiredSampleCount)
+    SDL_GpuSampleCount sampleCount)
 {
     CHECK_DEVICE_MAGIC(device, 0);
 
@@ -587,10 +587,10 @@ SDL_GpuSampleCount SDL_GpuGetBestSampleCount(
         CHECK_TEXTUREFORMAT_ENUM_INVALID(format, 0)
     }
 
-    return device->GetBestSampleCount(
+    return device->SupportsSampleCount(
         device->driverData,
         format,
-        desiredSampleCount);
+        sampleCount);
 }
 
 /* State Creation */

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -655,7 +655,7 @@ struct SDL_GpuDevice
         SDL_GpuTextureType type,
         SDL_GpuTextureUsageFlags usage);
 
-    SDL_GpuSampleCount (*GetBestSampleCount)(
+    SDL_bool (*SupportsSampleCount)(
         SDL_GpuRenderer *driverData,
         SDL_GpuTextureFormat format,
         SDL_GpuSampleCount desiredSampleCount);
@@ -748,7 +748,7 @@ struct SDL_GpuDevice
     ASSIGN_DRIVER_FUNC(QueryFence, name)                    \
     ASSIGN_DRIVER_FUNC(ReleaseFence, name)                  \
     ASSIGN_DRIVER_FUNC(SupportsTextureFormat, name)         \
-    ASSIGN_DRIVER_FUNC(GetBestSampleCount, name)
+    ASSIGN_DRIVER_FUNC(SupportsSampleCount, name)
 
 typedef struct SDL_GpuBootstrap
 {

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6872,7 +6872,7 @@ static SDL_bool VULKAN_SupportsSampleCount(
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     VkSampleCountFlags bits = IsDepthFormat(format) ? renderer->physicalDeviceProperties.properties.limits.framebufferDepthSampleCounts : renderer->physicalDeviceProperties.properties.limits.framebufferColorSampleCounts;
     VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sampleCount];
-    return bits & vkSampleCount;
+    return !!(bits & vkSampleCount);
 }
 
 static SDL_GpuTexture *VULKAN_CreateTexture(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -413,10 +413,7 @@ static VkSampleCountFlagBits SDLToVK_SampleCount[] = {
     VK_SAMPLE_COUNT_1_BIT,
     VK_SAMPLE_COUNT_2_BIT,
     VK_SAMPLE_COUNT_4_BIT,
-    VK_SAMPLE_COUNT_8_BIT,
-    VK_SAMPLE_COUNT_16_BIT,
-    VK_SAMPLE_COUNT_32_BIT,
-    VK_SAMPLE_COUNT_64_BIT
+    VK_SAMPLE_COUNT_8_BIT
 };
 
 static VkVertexInputRate SDLToVK_VertexInputRate[] = {
@@ -6867,26 +6864,15 @@ static SDL_GpuShader *VULKAN_CreateShader(
     return (SDL_GpuShader *)vulkanShader;
 }
 
-static SDL_GpuSampleCount VULKAN_GetBestSampleCount(
+static SDL_bool VULKAN_SupportsSampleCount(
     SDL_GpuRenderer *driverData,
     SDL_GpuTextureFormat format,
-    SDL_GpuSampleCount desiredSampleCount)
+    SDL_GpuSampleCount sampleCount)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    SDL_GpuSampleCount maxSupported;
-    VkSampleCountFlagBits bits = IsDepthFormat(format) ? renderer->physicalDeviceProperties.properties.limits.framebufferDepthSampleCounts : renderer->physicalDeviceProperties.properties.limits.framebufferColorSampleCounts;
-
-    if (bits & VK_SAMPLE_COUNT_8_BIT) {
-        maxSupported = SDL_GPU_SAMPLECOUNT_8;
-    } else if (bits & VK_SAMPLE_COUNT_4_BIT) {
-        maxSupported = SDL_GPU_SAMPLECOUNT_4;
-    } else if (bits & VK_SAMPLE_COUNT_2_BIT) {
-        maxSupported = SDL_GPU_SAMPLECOUNT_2;
-    } else {
-        maxSupported = SDL_GPU_SAMPLECOUNT_1;
-    }
-
-    return SDL_min(maxSupported, desiredSampleCount);
+    VkSampleCountFlags bits = IsDepthFormat(format) ? renderer->physicalDeviceProperties.properties.limits.framebufferDepthSampleCounts : renderer->physicalDeviceProperties.properties.limits.framebufferColorSampleCounts;
+    VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sampleCount];
+    return bits & vkSampleCount;
 }
 
 static SDL_GpuTexture *VULKAN_CreateTexture(
@@ -6900,10 +6886,6 @@ static SDL_GpuTexture *VULKAN_CreateTexture(
     VkComponentMapping swizzle;
     VulkanTextureContainer *container;
     VulkanTextureHandle *textureHandle;
-    SDL_GpuSampleCount actualSampleCount = VULKAN_GetBestSampleCount(
-        driverData,
-        textureCreateInfo->format,
-        textureCreateInfo->sampleCount);
 
     format = SDLToVK_SurfaceFormat[textureCreateInfo->format];
     swizzle = SDLToVK_SurfaceSwizzle[textureCreateInfo->format];
@@ -6926,7 +6908,7 @@ static SDL_GpuTexture *VULKAN_CreateTexture(
         textureCreateInfo->type,
         textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : textureCreateInfo->layerCountOrDepth,
         textureCreateInfo->levelCount,
-        SDLToVK_SampleCount[actualSampleCount],
+        SDLToVK_SampleCount[textureCreateInfo->sampleCount],
         format,
         swizzle,
         imageAspectFlags,

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -279,12 +279,12 @@ CreateMSAATexture(Uint32 drawablew, Uint32 drawableh)
     }
 
     msaatex_createinfo.type = SDL_GPU_TEXTURETYPE_2D;
-    msaatex_createinfo.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8;
+    msaatex_createinfo.format = SDL_GpuGetSwapchainTextureFormat(gpu_device, state->windows[0]);
     msaatex_createinfo.width = drawablew;
     msaatex_createinfo.height = drawableh;
     msaatex_createinfo.layerCountOrDepth = 1;
     msaatex_createinfo.levelCount = 1;
-    msaatex_createinfo.sampleCount = SDL_GPU_SAMPLECOUNT_4;
+    msaatex_createinfo.sampleCount = render_state.sample_count;
     msaatex_createinfo.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET_BIT | SDL_GPU_TEXTUREUSAGE_SAMPLER_BIT;
     msaatex_createinfo.props = 0;
 
@@ -532,17 +532,19 @@ init_render_state(int msaa)
     SDL_GpuReleaseTransferBuffer(gpu_device, buf_transfer);
 
     /* Determine which sample count to use */
-    render_state.sample_count = msaa ? SDL_GPU_SAMPLECOUNT_4 : SDL_GPU_SAMPLECOUNT_1;
+    render_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    if (msaa && SDL_GpuSupportsSampleCount(
+        gpu_device,
+        SDL_GpuGetSwapchainTextureFormat(gpu_device, state->windows[0]),
+        SDL_GPU_SAMPLECOUNT_4)) {
+        render_state.sample_count = SDL_GPU_SAMPLECOUNT_4;
+    }
 
     /* Set up the graphics pipeline */
 
     SDL_zero(pipelinedesc);
 
-    if (msaa) {
-        color_attachment_desc.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8;
-    } else {
-        color_attachment_desc.format = SDL_GpuGetSwapchainTextureFormat(gpu_device, state->windows[0]);
-    }
+    color_attachment_desc.format = SDL_GpuGetSwapchainTextureFormat(gpu_device, state->windows[0]);
 
     color_attachment_desc.blendState.blendEnable = 0;
     color_attachment_desc.blendState.alphaBlendOp = SDL_GPU_BLENDOP_ADD;


### PR DESCRIPTION
Resolves #218 

Removes `SDL_GpuGetBestSampleCount` in favor of a hard query: `SDL_GpuSupportsSampleCount`.
