### PR TITLE
Assert in BeginRenderPass if cycle is true and load op is LOAD

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1195,7 +1195,7 @@ SDL_GpuRenderPass *SDL_GpuBeginRenderPass(
             }
         }
 
-        if (depthStencilAttachmentInfo->cycle && (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD || depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD)) {
+        if (depthStencilAttachmentInfo != NULL && depthStencilAttachmentInfo->cycle && (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD || depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD)) {
             SDL_assert_release(!"Cannot cycle depth attachment when load op or stencil load op is LOAD!");
         }
     }

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1188,6 +1188,16 @@ SDL_GpuRenderPass *SDL_GpuBeginRenderPass(
     if (COMMAND_BUFFER_DEVICE->debugMode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         CHECK_ANY_PASS_IN_PROGRESS_RETURN_NULL
+
+        for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
+            if (colorAttachmentInfos[i].cycle && colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_LOAD) {
+                SDL_assert_release(!"Cannot cycle color attachment when load op is LOAD!");
+            }
+        }
+
+        if (depthStencilAttachmentInfo->cycle && (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD || depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD)) {
+            SDL_assert_release(!"Cannot cycle depth attachment when load op or stencil load op is LOAD!");
+        }
     }
 
     COMMAND_BUFFER_DEVICE->BeginRenderPass(

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -3396,13 +3396,20 @@ static void D3D11_BeginRenderPass(
 
     /* Set up the new color target bindings */
     for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
+        SDL_bool cycle;
+        if (colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_LOAD) {
+            cycle = SDL_FALSE;
+        } else {
+            cycle = colorAttachmentInfos[i].cycle;
+        }
+
         D3D11TextureContainer *container = (D3D11TextureContainer *)colorAttachmentInfos[i].texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
             container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
             colorAttachmentInfos[i].mipLevel,
-            colorAttachmentInfos[i].cycle);
+            cycle);
 
         if (subresource->msaaHandle != NULL) {
             d3d11CommandBuffer->colorTargetResolveTexture[i] = subresource->parent;
@@ -3436,13 +3443,21 @@ static void D3D11_BeginRenderPass(
 
     /* Get the DSV for the depth stencil attachment, if applicable */
     if (depthStencilAttachmentInfo != NULL) {
+        SDL_bool cycle;
+
+        if (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD || depthStencilAttachmentInfo->stencilLoadOp == SDL_GPU_LOADOP_LOAD) {
+            cycle = SDL_FALSE;
+        } else {
+            cycle = depthStencilAttachmentInfo->cycle;
+        }
+
         D3D11TextureContainer *container = (D3D11TextureContainer *)depthStencilAttachmentInfo->texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
             0,
             0,
-            depthStencilAttachmentInfo->cycle);
+            cycle);
 
         dsv = subresource->depthStencilTargetView;
 

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -3396,20 +3396,13 @@ static void D3D11_BeginRenderPass(
 
     /* Set up the new color target bindings */
     for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
-        SDL_bool cycle;
-        if (colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_LOAD) {
-            cycle = SDL_FALSE;
-        } else {
-            cycle = colorAttachmentInfos[i].cycle;
-        }
-
         D3D11TextureContainer *container = (D3D11TextureContainer *)colorAttachmentInfos[i].texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
             container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
             colorAttachmentInfos[i].mipLevel,
-            cycle);
+            colorAttachmentInfos[i].cycle);
 
         if (subresource->msaaHandle != NULL) {
             d3d11CommandBuffer->colorTargetResolveTexture[i] = subresource->parent;
@@ -3443,21 +3436,13 @@ static void D3D11_BeginRenderPass(
 
     /* Get the DSV for the depth stencil attachment, if applicable */
     if (depthStencilAttachmentInfo != NULL) {
-        SDL_bool cycle;
-
-        if (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD || depthStencilAttachmentInfo->stencilLoadOp == SDL_GPU_LOADOP_LOAD) {
-            cycle = SDL_FALSE;
-        } else {
-            cycle = depthStencilAttachmentInfo->cycle;
-        }
-
         D3D11TextureContainer *container = (D3D11TextureContainer *)depthStencilAttachmentInfo->texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
             0,
             0,
-            cycle);
+            depthStencilAttachmentInfo->cycle);
 
         dsv = subresource->depthStencilTargetView;
 

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3775,20 +3775,13 @@ static void D3D12_BeginRenderPass(
     D3D12_CPU_DESCRIPTOR_HANDLE rtvs[MAX_COLOR_TARGET_BINDINGS];
 
     for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
-        SDL_bool cycle;
-        if (colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_LOAD) {
-            cycle = SDL_FALSE;
-        } else {
-            cycle = colorAttachmentInfos[i].cycle;
-        }
-
         D3D12TextureContainer *container = (D3D12TextureContainer *)colorAttachmentInfos[i].texture;
         D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d12CommandBuffer,
             container,
             container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
             colorAttachmentInfos[i].mipLevel,
-            cycle,
+            colorAttachmentInfos[i].cycle,
             D3D12_RESOURCE_STATE_RENDER_TARGET);
 
         Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layerOrDepthPlane : 0;
@@ -3820,23 +3813,13 @@ static void D3D12_BeginRenderPass(
 
     D3D12_CPU_DESCRIPTOR_HANDLE dsv;
     if (depthStencilAttachmentInfo != NULL) {
-        SDL_bool cycle;
-
-        if (
-            depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD ||
-            depthStencilAttachmentInfo->stencilLoadOp == SDL_GPU_LOADOP_LOAD) {
-            cycle = SDL_FALSE;
-        } else {
-            cycle = depthStencilAttachmentInfo->cycle;
-        }
-
         D3D12TextureContainer *container = (D3D12TextureContainer *)depthStencilAttachmentInfo->texture;
         D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d12CommandBuffer,
             container,
             0,
             0,
-            cycle,
+            depthStencilAttachmentInfo->cycle,
             D3D12_RESOURCE_STATE_DEPTH_WRITE);
 
         if (

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -7816,13 +7816,6 @@ static void VULKAN_BeginRenderPass(
     }
 
     for (i = 0; i < colorAttachmentCount; i += 1) {
-        SDL_bool cycle;
-        if (colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_LOAD) {
-            cycle = SDL_FALSE;
-        } else {
-            cycle = colorAttachmentInfos[i].cycle;
-        }
-
         VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
@@ -7830,7 +7823,7 @@ static void VULKAN_BeginRenderPass(
             textureContainer,
             textureContainer->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
             colorAttachmentInfos[i].mipLevel,
-            cycle,
+            colorAttachmentInfos[i].cycle,
             VULKAN_TEXTURE_USAGE_MODE_COLOR_ATTACHMENT);
 
         if (subresource->msaaTexHandle != NULL) {
@@ -7854,16 +7847,6 @@ static void VULKAN_BeginRenderPass(
     vulkanCommandBuffer->colorAttachmentSubresourceCount = colorAttachmentCount;
 
     if (depthStencilAttachmentInfo != NULL) {
-        SDL_bool cycle;
-
-        if (
-            depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD ||
-            depthStencilAttachmentInfo->stencilLoadOp == SDL_GPU_LOADOP_LOAD) {
-            cycle = SDL_FALSE;
-        } else {
-            cycle = depthStencilAttachmentInfo->cycle;
-        }
-
         VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depthStencilAttachmentInfo->texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
@@ -7871,7 +7854,7 @@ static void VULKAN_BeginRenderPass(
             textureContainer,
             0,
             0,
-            cycle,
+            depthStencilAttachmentInfo->cycle,
             VULKAN_TEXTURE_USAGE_MODE_DEPTH_STENCIL_ATTACHMENT);
 
         clearCount += 1;


### PR DESCRIPTION
It makes no sense to cycle and load in a render pass, and if the client asks to do this it indicates a fundamental misunderstanding, so we should assert when this happens. 